### PR TITLE
Theme: lazily resolve font, fall back to system monospace (closes #12)

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -5,6 +5,7 @@
 - Use wxAUI based toolbar system
 - Remember configured layout between fbide restarts
 - Encode correct platform values in Windows manifest files
+- Theme: fall back to the system default monospace font when the configured face isn't installed (#12)
 
 # Changes since fbide 0.4.5.
 

--- a/src/lib/config/Theme.cpp
+++ b/src/lib/config/Theme.cpp
@@ -253,6 +253,45 @@ void Theme::load(const wxString& themePath, const bool reset) {
         ini.SetPath("/" + wxString(getThemeCategoryName(cat)));
         m_categories[static_cast<std::size_t>(cat)] = read<Entry>(ini, wxEmptyString);
     }
+    // Qualified to disambiguate from the `reset` bool parameter.
+    this->reset();
+}
+
+auto Theme::getResolvedFont(const bool bold, const bool italic, const bool underlined) const -> wxFont {
+    if (!m_resolvedFont.IsOk()) {
+        resolveFontFace();
+    }
+    wxFont font = m_resolvedFont;
+    if (bold) {
+        font.MakeBold();
+    }
+    if (italic) {
+        font.MakeItalic();
+    }
+    if (underlined) {
+        font.MakeUnderlined();
+    }
+    return font;
+}
+
+void Theme::reset() {
+    m_resolvedFont = wxFont {};
+}
+
+void Theme::resolveFontFace() const {
+    const int size = m_fontSize > 0 ? m_fontSize : 12;
+    auto info = wxFontInfo(size).Family(wxFONTFAMILY_MODERN);
+
+    if (!m_font.IsEmpty() && wxFontEnumerator::IsValidFacename(m_font)) {
+        info.FaceName(m_font);
+    } else {
+        if (!m_font.IsEmpty()) {
+            wxLogWarning("Theme font '%s' is not installed; using system default monospace.", m_font);
+        }
+        // Empty face + TELETYPE → wx picks the platform default monospace.
+        info.Family(wxFONTFAMILY_TELETYPE);
+    }
+    m_resolvedFont = wxFont(info);
 }
 
 void Theme::loadV4(const wxString& themePath) {
@@ -294,9 +333,7 @@ void Theme::loadV4(const wxString& themePath) {
             }
         }
     }
-    if (m_font.IsEmpty()) {
-        m_font = "Courier New";
-    }
+    // Final validation handled by resolveFontFace() at the end.
 
     // Editor-wide entries
     m_lineNumber = readLegacyColors(ini, "/linenumber", *wxWHITE, wxColour(0xC0, 0xC0, 0xC0));
@@ -332,6 +369,7 @@ void Theme::loadV4(const wxString& themePath) {
     mapCategory(ThemeCategory::Label, "/identifier");
     mapCategory(ThemeCategory::Preprocessor, "/preprocessor");
     mapCategory(ThemeCategory::Error, "/identifier");
+    reset();
 }
 
 void Theme::save(const wxString& newThemePath) {

--- a/src/lib/config/Theme.hpp
+++ b/src/lib/config/Theme.hpp
@@ -110,12 +110,11 @@ public:
         m_categories[static_cast<std::size_t>(category)] = entry;
     }
 
-    // -----------------------------------------------------------------------
-    // Style property getters and setters
-    // -----------------------------------------------------------------------
+    // Style property getters and setters. Every setter calls reset()
+    // to invalidate the cached runtime font.
     #define FUNCS(GETTER, MEMBER, TYPE)                                                \
         [[nodiscard]] auto get## GETTER() const -> const TYPE& { return m_## MEMBER; } \
-        void set## GETTER(const TYPE& MEMBER) { m_## MEMBER = MEMBER; }
+        void set## GETTER(const TYPE& MEMBER) { m_## MEMBER = MEMBER; reset(); }
         DEFINE_THEME_PROPERTY(FUNCS)
     #undef FUNCS
 
@@ -128,9 +127,25 @@ public:
     /// Return `color` if valid, otherwise the default-category background.
     [[nodiscard]] auto background(const wxColour& color) const -> const wxColour&;
 
+    /// Runtime wxFont built from the theme's font + size. Falls back
+    /// to the platform default monospace face when the configured
+    /// face isn't installed. `m_font` itself is never mutated.
+    [[nodiscard]] auto getResolvedFont(
+        bool bold = false,
+        bool italic = false,
+        bool underlined = false
+    ) const -> wxFont;
+
 private:
     /// Internal load entry — `reset` controls whether existing fields clear first.
     void load(const wxString& themePath, bool reset);
+    /// Invalidate the cached runtime font.
+    void reset();
+    /// Build the runtime wxFont, substituting the system monospace face
+    /// when the configured one isn't installed.
+    void resolveFontFace() const;
+
+    mutable wxFont m_resolvedFont;       ///< Lazy runtime cache; never persisted.
 
     wxString m_themePath;                                ///< Current backing file path.
     std::array<Entry, kThemeCategoryCount> m_categories {}; ///< Per-`ThemeCategory` style entries.

--- a/src/lib/editor/Editor.cpp
+++ b/src/lib/editor/Editor.cpp
@@ -156,14 +156,7 @@ void Editor::applyTheme() {
     const auto& defaultEntry = theme.get(ThemeCategory::Default);
     const auto& defaultColors = defaultEntry.colors;
 
-    m_font = wxFont(
-        theme.getFontSize(),
-        wxFONTFAMILY_MODERN,
-        wxFONTSTYLE_NORMAL,
-        wxFONTWEIGHT_NORMAL,
-        false,
-        theme.getFont()
-    );
+    m_font = theme.getResolvedFont();
 
     StyleSetForeground(wxSTC_STYLE_DEFAULT, defaultColors.foreground);
     StyleSetBackground(wxSTC_STYLE_DEFAULT, defaultColors.background);

--- a/tests/ThemeTests.cpp
+++ b/tests/ThemeTests.cpp
@@ -64,6 +64,56 @@ TEST_F(ThemeTests, SaveAndReload) {
     wxRemoveFile(tmpFile);
 }
 
+// Regression for #12 — when the theme references a font that's not
+// installed, getResolvedFont() returns a wxFont with a face wx
+// recognises on this system, while getFont() preserves the original
+// (bogus) name as written in the file so save / load round-trips
+// don't mutate user content.
+TEST_F(ThemeTests, MissingFontFallsBackToSystemMonospace) {
+    const wxString tmpFile = wxFileName::CreateTempFileName("fbide_theme") + ".ini";
+    constexpr auto kBogusFont = "Definitely Not An Installed Face XYZQ";
+    {
+        wxFFile out(tmpFile, "w");
+        ASSERT_TRUE(out.IsOpened());
+        out.Write(wxString::Format(
+            "version=0.5.0\n"
+            "font=%s\n"
+            "fontSize=11\n",
+            kBogusFont
+        ));
+    }
+
+    Theme theme;
+    theme.load(tmpFile);
+
+    // Original face name preserved on disk (no mutation).
+    EXPECT_EQ(theme.getFont(), kBogusFont);
+
+    // Resolved font is a usable wxFont on this system.
+    const auto resolved = theme.getResolvedFont();
+    EXPECT_TRUE(resolved.IsOk());
+    EXPECT_NE(resolved.GetFaceName(), kBogusFont);
+    EXPECT_FALSE(resolved.GetFaceName().IsEmpty());
+    EXPECT_TRUE(wxFontEnumerator::IsValidFacename(resolved.GetFaceName()))
+        << "Resolved face '" << resolved.GetFaceName().ToStdString()
+        << "' was not registered as a valid face on this system.";
+
+    // Style variants flow through the same base.
+    const auto bold = theme.getResolvedFont(/*bold=*/true);
+    EXPECT_TRUE(bold.GetWeight() == wxFONTWEIGHT_BOLD);
+
+    // Mutating font / fontSize via setters re-runs the resolver — no
+    // explicit invalidation step required by callers (theme editor,
+    // settings dialog).
+    theme.setFont("Courier New");
+    EXPECT_EQ(theme.getResolvedFont().GetFaceName(), "Courier New");
+
+    theme.setFontSize(20);
+    EXPECT_EQ(theme.getResolvedFont().GetPointSize(), 20);
+
+    wxRemoveFile(tmpFile);
+}
+
 TEST_F(ThemeTests, SaveMigratesFbtToIni) {
     // Copy classic.fbt somewhere writable so we can save it.
     const wxString srcFbt = testDataPath + "classic.fbt";


### PR DESCRIPTION
Closes #12.

wxFont silently swaps an unknown face name for whatever it considers default,
so a theme referencing a font that's not installed (Cascadia Mono, JetBrains
Mono, ...) ended up with proportional text and no warning.

## Approach

- New `Theme::getResolvedFont(bold, italic, underlined)` returns the runtime
  wxFont. Built on first call; the cache (`mutable m_resolvedFont`) is
  invalidated by `reset()` and rebuilt on the next request.
- The auto-generated property setters call `reset()` uniformly on every
  mutation. Slight overshoot for unrelated properties, but keeps the macro
  simple and avoids forgotten invalidations.
- `resolveFontFace()` builds a wxFont with the configured face when
  `wxFontEnumerator` confirms it is installed; otherwise constructs with
  `wxFONTFAMILY_TELETYPE` + empty face so wx picks the platform default
  monospace.
- A `wxLogWarning` fires when a named face is dropped.
- `m_font` is never mutated; `Theme::save()` round-trips the original face
  name verbatim.

## Misc

- `Editor::applyTheme` drops its inline `wxFont(...)` construction in favour
  of `theme.getResolvedFont()` -- single line.
- `change-log.md` lists the new fallback under the upcoming release notes.

## Tests

- `ThemeTests.MissingFontFallsBackToSystemMonospace` covers preservation of
  `m_font`, validity of the resolved face, the bold-variant flag, and that
  `setFont` / `setFontSize` round-trip the new values through
  `getResolvedFont`.
- `ctest`: 323/323 pass.