### PR TITLE
Shortcuts: F2 toggles Browser, Shift+F2 opens Sub/Function browser (closes #9)

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -6,6 +6,7 @@
 - Remember configured layout between fbide restarts
 - Encode correct platform values in Windows manifest files
 - Theme: fall back to the system default monospace font when the configured face isn't installed (#12)
+- Shortcuts: `F2` now toggles the Browser pane; `Shift+F2` opens the Sub/Function browser (#9)
 
 # Changes since fbide 0.4.5.
 

--- a/resources/ide/shortcuts_linux.ini
+++ b/resources/ide/shortcuts_linux.ini
@@ -40,7 +40,8 @@ gotoLine=Ctrl+G
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run ---
 compile=Ctrl+F9

--- a/resources/ide/shortcuts_macos.ini
+++ b/resources/ide/shortcuts_macos.ini
@@ -46,7 +46,8 @@ gotoLine=Ctrl+L
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run (Xcode-style) ---
 compile=Ctrl+B

--- a/resources/ide/shortcuts_win.ini
+++ b/resources/ide/shortcuts_win.ini
@@ -40,7 +40,8 @@ gotoLine=Ctrl+G
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run ---
 compile=Ctrl+F9

--- a/resources/pristine/shortcuts_linux.ini
+++ b/resources/pristine/shortcuts_linux.ini
@@ -40,7 +40,8 @@ gotoLine=Ctrl+G
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run ---
 compile=Ctrl+F9

--- a/resources/pristine/shortcuts_macos.ini
+++ b/resources/pristine/shortcuts_macos.ini
@@ -46,7 +46,8 @@ gotoLine=Ctrl+L
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run (Xcode-style) ---
 compile=Ctrl+B

--- a/resources/pristine/shortcuts_win.ini
+++ b/resources/pristine/shortcuts_win.ini
@@ -40,7 +40,8 @@ gotoLine=Ctrl+G
 
 ; --- View ---
 viewResult=F4
-viewSubs=F2
+viewBrowser=F2
+viewSubs=Shift+F2
 
 ; --- Run ---
 compile=Ctrl+F9


### PR DESCRIPTION
Closes #9.  F2 previously opened the Sub/Function browser. Now it toggles the Browser sidebar (`viewBrowser` is `wxITEM_CHECK`, so F2 flips the AUI pane via the existing CommandEntry visitor). Sub/Function browser keeps its action shortcut on **Shift+F2**.  ## Changes  - `resources/ide/shortcuts_{win,linux,macos}.ini` - `resources/pristine/shortcuts_{win,linux,macos}.ini`  For each file: ``` viewBrowser=F2 viewSubs=Shift+F2 ```  ## Tests  Config-only change. `ctest`: 323/323 pass.