### PR TITLE
28 when rem is followed by newline next line is treated as a comment

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,6 +1,7 @@
 # Change since 0.5.0-beta.2
 
 - Fixed issue with auto indent not working when keyword case transform was disabled (#24)
+- Fixed issue with REM comment followed by newline, which caused next line to be a comment (#28)
 
 # Change since 0.5.0-beta.1
 

--- a/src/lib/editor/lexilla/FBSciLexer.cpp
+++ b/src/lib/editor/lexilla/FBSciLexer.cpp
@@ -501,7 +501,7 @@ auto FBSciLexer::identifyKeyword() noexcept -> bool {
     m_sc->GetCurrentLowered(m_identBuffer.data(), m_identBuffer.size());
     if (strcmp("rem", m_identBuffer.data()) == 0) {
         m_sc->ChangeState(+ThemeCategory::Comment);
-        return false;
+        return m_sc->atLineEnd;
     }
 
     if (m_isFirst) {
@@ -592,6 +592,9 @@ void FBSciLexer::lexPreprocessor() noexcept {
 
         if (strcmp("rem", m_identBuffer.data()) == 0) {
             m_sc->ChangeState(+ThemeCategory::Comment);
+            if (m_sc->atLineEnd) {
+                resetToDefault();
+            }
             return;
         }
 

--- a/tests/FBSciLexerTests.cpp
+++ b/tests/FBSciLexerTests.cpp
@@ -201,6 +201,25 @@ TEST_F(FBSciLexerTests, NestedMultilineCommentWithLineBreaks) {
     );
 }
 
+TEST_F(FBSciLexerTests, RemAtLineEndDoesNotContinueToNextLine) {
+    // `rem` at the very end of a line is a comment for that line only — the
+    // next line must lex normally. Regression for #28.
+    expectStyles(
+        "foobar rem\nfoobar",
+        "IIIIII CCC IIIIII"
+    );
+}
+
+TEST_F(FBSciLexerTests, PreprocessorRemAtLineEndDoesNotContinueToNextLine) {
+    // Same rule applies inside a preprocessor line: `REM` at the end of the
+    // `#define` line is a trailing comment, not a state that bleeds into the
+    // following identifier. Regression for #28.
+    expectStyles(
+        "#define foo 1 REM\nfoobar",
+        "##############CCC IIIIII"
+    );
+}
+
 // endregion
 
 // region ---------- Numbers ----------


### PR DESCRIPTION
closes #28 