### PR TITLE
Remove classic wxToolBar code path, AUI toolbar everywhere

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -10,6 +10,7 @@
 - Fixed auto-indent and code formatter no longer add `End Asm` closer / indent body for single-line `asm` (#46)
 - Fixed preprocessor lexing of `"_"` which would cause to treat `_` as a line continuation (#54)
 - Chnaged IDE resource directory carrying a `READONLY` sentinel file is now mirrored to `<user-data-dir>/ide` on launch and loaded/saved from there. (#39)
+- Removed classic `wxToolBar` code path; the wxAUI toolbar is now the only implementation on every platform (#11)
 - Changed log now writes to the per-user data directory by default and flushes after each record so crash diagnostics survive; added `--log-path` to override the location
 
 # Changes since 0.5.0-beta.2

--- a/doxygen/commands.md
+++ b/doxygen/commands.md
@@ -18,7 +18,7 @@ toggles) that surface it.
 | `enabled`        | Broad UI gate (set by `UIManager::applyState`).         |
 | `forceDisabled`  | Per-editor mask (set by `DocumentManager`).             |
 | `checked`        | Toggle state for `wxITEM_CHECK` entries.                |
-| `binds`          | `vector<variant<wxMenu*, wxMenuItem*, wxToolBarToolBase*, wxAuiManager*, ConfigManager*>>` |
+| `binds`          | `vector<variant<wxMenu*, wxMenuItem*, wxAuiToolBar*, wxAuiManager*, ConfigManager*>>` |
 
 `CommandManager` (`src/lib/command/CommandManager.hpp`) owns every entry
 in two lookup tables: by name, and by id. The constructor seeds the
@@ -52,7 +52,7 @@ CommandId.hpp   : enum CommandId { ..., Compile, ... }
 CommandManager  : addCommands({ {.id=+CommandId::Compile, .name="compile"} })
                   EVT_MENU(+CommandId::Compile, CommandManager::onCompile)
 UIManager       : while building "run" menu, lookup "compile" by name,
-                  attach the wxMenuItem* / wxToolBarToolBase* to entry.binds
+                  attach the wxMenuItem* / wxAuiToolBar* to entry.binds
 runtime         : F5 / click → wxEVT_MENU id=+CommandId::Compile
                   → CommandManager::onCompile
                   → m_ctx.getCompilerManager().compile()

--- a/doxygen/ui.md
+++ b/doxygen/ui.md
@@ -18,7 +18,7 @@ construction.
 | Member               | Wrapper             | Notes                                       |
 |----------------------|---------------------|---------------------------------------------|
 | `m_frame`            | `Unowned<wxFrame>`  | Top-level frame; wx parent of all chrome.   |
-| `m_toolbar`          | `Unowned<wxToolBar>`| Built from `layout.ini`'s `toolbar=` line.  |
+| `m_auiToolbar`       | `Unowned<wxAuiToolBar>` | Built from `layout.ini`'s `toolbar=` line, docked via `m_aui`. |
 | `m_notebook`         | `Unowned<wxAuiNotebook>` | Document tabs.                         |
 | `m_sideBar`          | `Unowned<wxAuiNotebook>` | Browser / Subs sidebar notebook.       |
 | `m_console`          | `Unowned<OutputConsole>` | Build / error output.                  |
@@ -43,7 +43,7 @@ createMainFrame()
     ├─ configureMenuBar()   ← walks layout.ini [menu] sections,
     │                          calls CommandManager::find(name)
     │                          to attach wxMenuItem* binds.
-    ├─ configureToolBar()   ← same model, wxToolBarToolBase* binds.
+    ├─ configureToolBar()   ← same model, wxAuiToolBar* binds.
     ├─ generateExternalLinks() ← Help-menu external-links submenu
     │                            via CommandManager::registerExternalLink.
     ├─ DocumentManager::attachNotebook()  ← bind tab-strip events

--- a/resources/ide/config_linux.ini
+++ b/resources/ide/config_linux.ini
@@ -33,15 +33,6 @@ helpFile=FB-manual-1.10.1.chm
 [general]
 splashScreen=1
 ; ----------------------------------------------------------------------------
-; Toolbar settings.
-;   useAui  Build the main toolbar as a wxAUI-managed pane instead of
-;           the classic frame toolbar. Default on (set to 0 to fall
-;           back to the classic frame wxToolBar). Not exposed in the
-;           Settings dialog yet. See GitHub issue #11.
-; ----------------------------------------------------------------------------
-[toolbar]
-useAui=1
-; ----------------------------------------------------------------------------
 ; Toggle state for togglable menu/toolbar commands.
 ; ----------------------------------------------------------------------------
 [commands]

--- a/resources/ide/config_macos.ini
+++ b/resources/ide/config_macos.ini
@@ -33,15 +33,6 @@ helpFile=
 [general]
 splashScreen=1
 ; ----------------------------------------------------------------------------
-; Toolbar settings.
-;   useAui  Build the main toolbar as a wxAUI-managed pane instead of
-;           the classic frame toolbar. Off on macOS by default — the
-;           native unified toolbar reads better on macOS than the
-;           wxAUI variant. Set to 1 to opt in. See GitHub issue #11.
-; ----------------------------------------------------------------------------
-[toolbar]
-useAui=0
-; ----------------------------------------------------------------------------
 ; Toggle state for togglable menu/toolbar commands.
 ; ----------------------------------------------------------------------------
 [commands]

--- a/resources/pristine/config_linux.ini
+++ b/resources/pristine/config_linux.ini
@@ -29,15 +29,6 @@ appearance=system
 [general]
 splashScreen=1
 ; ----------------------------------------------------------------------------
-; Toolbar settings.
-;   useAui  Build the main toolbar as a wxAUI-managed pane instead of
-;           the classic frame toolbar. Default on (set to 0 to fall
-;           back to the classic frame wxToolBar). Not exposed in the
-;           Settings dialog yet. See GitHub issue #11.
-; ----------------------------------------------------------------------------
-[toolbar]
-useAui=1
-; ----------------------------------------------------------------------------
 ; Toggle state for togglable menu/toolbar commands.
 ; ----------------------------------------------------------------------------
 [commands]

--- a/resources/pristine/config_macos.ini
+++ b/resources/pristine/config_macos.ini
@@ -27,15 +27,6 @@ appearance=system
 [general]
 splashScreen=1
 ; ----------------------------------------------------------------------------
-; Toolbar settings.
-;   useAui  Build the main toolbar as a wxAUI-managed pane instead of
-;           the classic frame toolbar. Off on macOS by default — the
-;           native unified toolbar reads better on macOS than the
-;           wxAUI variant. Set to 1 to opt in. See GitHub issue #11.
-; ----------------------------------------------------------------------------
-[toolbar]
-useAui=0
-; ----------------------------------------------------------------------------
 ; Toggle state for togglable menu/toolbar commands.
 ; ----------------------------------------------------------------------------
 [commands]

--- a/resources/pristine/config_win.ini
+++ b/resources/pristine/config_win.ini
@@ -28,15 +28,6 @@ appearance=
 [general]
 splashScreen=1
 ; ----------------------------------------------------------------------------
-; Toolbar settings.
-;   useAui  Build the main toolbar as a wxAUI-managed pane instead of
-;           the classic frame toolbar. Default on (set to 0 to fall
-;           back to the classic frame wxToolBar). Not exposed in the
-;           Settings dialog yet. See GitHub issue #11.
-; ----------------------------------------------------------------------------
-[toolbar]
-useAui=1
-; ----------------------------------------------------------------------------
 ; Toggle state for togglable menu/toolbar commands.
 ; ----------------------------------------------------------------------------
 [commands]

--- a/src/lib/command/CommandEntry.cpp
+++ b/src/lib/command/CommandEntry.cpp
@@ -53,20 +53,6 @@ void CommandEntry::update() {
                 item->GetMenu()->UpdateUI();
             }
         },
-        [this, effectiveEnabled](wxToolBarToolBase* tool) {
-            bool refresh = false;
-            if (tool->IsEnabled() != effectiveEnabled) {
-                tool->Enable(effectiveEnabled);
-                refresh = true;
-            }
-            if (tool->CanBeToggled() && tool->IsToggled() != checked) {
-                tool->Toggle(checked);
-                refresh = true;
-            }
-            if (refresh) {
-                tool->GetToolBar()->Realize();
-            }
-        },
         [this, effectiveEnabled](wxAuiToolBar* tb) {
             // wxAuiToolBar enable / toggle / state queries are id-keyed
             // on the parent toolbar; the per-tool wxAuiToolBarItem has

--- a/src/lib/command/CommandEntry.hpp
+++ b/src/lib/command/CommandEntry.hpp
@@ -22,7 +22,7 @@ struct CommandEntry final {
     /// `wxAuiToolBar*` carries the parent toolbar — wxAuiToolBarItem
     /// has no enable / toggle of its own, those go through the parent
     /// keyed by entry id.
-    using Bind = std::variant<wxMenu*, wxMenuItem*, wxToolBarToolBase*, wxAuiToolBar*, wxAuiManager*, ConfigManager*>;
+    using Bind = std::variant<wxMenu*, wxMenuItem*, wxAuiToolBar*, wxAuiManager*, ConfigManager*>;
 
     /// Get the bound control of type `T*`, or `nullptr` if none exists.
     template<typename T>

--- a/src/lib/ui/UIManager.cpp
+++ b/src/lib/ui/UIManager.cpp
@@ -395,31 +395,19 @@ void UIManager::configureToolBar() {
         const auto& items = cfg.layout().at("toolbar");
         const auto& commands = cfg.locale().at("commands");
 
-        // Experimental: route the toolbar through wxAUI when
-        // `toolbar.useAui=1` in config. Off by default; not yet exposed
-        // in the Settings dialog. See GitHub issue #11.
-        const bool useAui = cfg.config().get_or("toolbar.useAui", false);
-        const bool createTools = (m_toolbar == nullptr && m_auiToolbar == nullptr);
+        const bool createTools = (m_auiToolbar == nullptr);
 
         if (createTools) {
-            if (useAui) {
-                m_auiToolbar = make_unowned<wxAuiToolBar>(
-                    m_frame, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                    wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_GRIPPER | wxAUI_TB_OVERFLOW
-                );
-            } else {
-                m_toolbar = m_frame->CreateToolBar(wxNO_BORDER | wxTB_HORIZONTAL | wxTB_FLAT);
-            }
+            m_auiToolbar = make_unowned<wxAuiToolBar>(
+                m_frame, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_GRIPPER | wxAUI_TB_OVERFLOW
+            );
         }
 
         for (const auto& key : items.asArray()) {
             if (key == "-") {
                 if (createTools) {
-                    if (m_auiToolbar != nullptr) {
-                        m_auiToolbar->AddSeparator();
-                    } else {
-                        m_toolbar->AddSeparator();
-                    }
+                    m_auiToolbar->AddSeparator();
                 }
                 continue;
             }
@@ -437,17 +425,12 @@ void UIManager::configureToolBar() {
 
             // Reconfigure path (locale change etc.) — refresh tooltips,
             // skip re-add.
-            if (m_auiToolbar != nullptr && entry->get<wxAuiToolBar>() != nullptr) {
+            if (entry->get<wxAuiToolBar>() != nullptr) {
                 if (auto* item = m_auiToolbar->FindTool(entry->id)) {
                     item->SetLabel(name);
                     item->SetShortHelp(help);
                     item->SetLongHelp(help);
                 }
-                continue;
-            }
-            if (m_toolbar != nullptr && entry->get<wxToolBarToolBase>() != nullptr) {
-                m_toolbar->SetToolShortHelp(entry->id, help);
-                m_toolbar->SetToolLongHelp(entry->id, help);
                 continue;
             }
 
@@ -457,34 +440,25 @@ void UIManager::configureToolBar() {
                 continue;
             }
 
-            if (m_auiToolbar != nullptr) {
-                m_auiToolbar->AddTool(entry->id, name, bitmap, help, entry->kind);
-                m_auiToolbar->SetToolLongHelp(entry->id, help);
-                entry->binds.push_back(m_auiToolbar.get());
-            } else {
-                auto* tool = m_toolbar->AddTool(entry->id, name, bitmap, help, entry->kind);
-                entry->binds.push_back(tool);
-            }
+            m_auiToolbar->AddTool(entry->id, name, bitmap, help, entry->kind);
+            m_auiToolbar->SetToolLongHelp(entry->id, help);
+            entry->binds.push_back(m_auiToolbar.get());
         }
 
         if (createTools) {
-            if (m_auiToolbar != nullptr) {
-                m_auiToolbar->Realize();
-                m_aui.AddPane(
-                    m_auiToolbar.get(),
-                    wxAuiPaneInfo()
-                        .Name("toolbar")
-                        .ToolbarPane()
-                        .Top()
-                        .Gripper(false)
-                        .CaptionVisible(false)
-                        .DockFixed(true)
-                        .CloseButton(false)
-                        .PaneBorder(false)
-                );
-            } else {
-                m_toolbar->Realize();
-            }
+            m_auiToolbar->Realize();
+            m_aui.AddPane(
+                m_auiToolbar.get(),
+                wxAuiPaneInfo()
+                    .Name("toolbar")
+                    .ToolbarPane()
+                    .Top()
+                    .Gripper(false)
+                    .CaptionVisible(false)
+                    .DockFixed(true)
+                    .CloseButton(false)
+                    .PaneBorder(false)
+            );
         }
     } catch (const std::exception& ex) {
         wxLogError("Invalid layout config for toolbar: %s", ex.what());
@@ -694,9 +668,8 @@ void UIManager::setTitle(const wxString& title) {
 
 void UIManager::disable(const std::ranges::range auto& range) const {
     // Route every state change through CommandEntry. The entry's
-    // visitor handles each bound control type (menu item, classic
-    // wxToolBar tool, wxAuiToolBar tool), so this loop doesn't care
-    // which toolbar flavour is active.
+    // visitor handles each bound control type (menu item, AUI toolbar
+    // tool), so this loop stays control-agnostic.
     //
     // Semantics (preserved from the previous direct-poke version):
     // commands listed in `range` get disabled, every other mutable id

--- a/src/lib/ui/UIManager.hpp
+++ b/src/lib/ui/UIManager.hpp
@@ -164,8 +164,7 @@ private:
     Unowned<CompilerLog> m_compilerLog;                 ///< Compiler-log dialog (wx-parented, hidden until shown).
     Unowned<OutputConsole> m_console;                   ///< Build/run output pane.
     Unowned<wxFrame> m_frame;                           ///< Top-level frame.
-    Unowned<wxToolBar> m_toolbar;                       ///< Classic frame toolbar (set when `toolbar.useAui=0`).
-    Unowned<wxAuiToolBar> m_auiToolbar;                 ///< AUI-managed toolbar pane (set when `toolbar.useAui=1`).
+    Unowned<wxAuiToolBar> m_auiToolbar;                 ///< AUI-managed toolbar pane.
     Unowned<wxAuiNotebook> m_notebook;                  ///< Document tabs.
     Unowned<wxAuiNotebook> m_sideBar;                   ///< Sidebar (Browser/Subs) notebook.
     std::vector<wxMenuItem*> m_externalLinkItems;       ///< Live menu items in the dynamic external-links submenu.


### PR DESCRIPTION
The classic wxToolBar branch was carried alongside the wxAUI variant behind a toolbar.useAui config flag. wxAUI is the better experience on every platform we target — it docks, floats, and integrates with the saved AUI perspective. Drop the duplicate path and the flag.

- CommandEntry: drop wxToolBarToolBase* from the Bind variant and its visitor case in update().
- UIManager: drop m_toolbar; configureToolBar() always builds a wxAuiToolBar pane and adds it to the AUI manager.
- config_<plat>.ini (pristine + ide): remove the now-unused [toolbar] section and its comment block.
- Doxygen: update ui.md / commands.md to reference wxAuiToolBar.

closes #40 