### PR TITLE
Sort out run/compile command placeholders (#45)

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -13,6 +13,7 @@
 - Removed classic `wxToolBar` code path; the wxAUI toolbar is now the only implementation on every platform (#11)
 - Added Linux AppImage to the release pipeline; `-DBUILD_APPIMAGE=ON` switches the install layout to FHS and points the resource resolver at `share/fbide/ide/` (#66)
 - Changed log now writes to the per-user data directory by default and flushes after each record so crash diagnostics survive; added `--log-path` to override the location
+- Changed `<$terminal>` placeholder is now read from `compiler.terminal` config and is a launcher prefix that runs the program in a new terminal (Win: `cmd /C start "" cmd /K`, Linux: `x-terminal-emulator -e`); added a click-to-insert placeholder reference table to the Compiler settings tab (#45)
 
 # Changes since 0.5.0-beta.2
 

--- a/resources/ide/config_linux.ini
+++ b/resources/ide/config_linux.ini
@@ -69,13 +69,15 @@ transformKeywords=1
 ; Compiler invocation templates.
 ;   <$fbc>       absolute path from `path` below
 ;   <$file>      current source file
-;   <$terminal>  platform default terminal
+;   <$terminal>  launcher prefix that runs the program in a new
+;                terminal window (cmd.exe / x-terminal-emulator -e / ...)
 ;   <$param>     program arguments (Parameters dialog)
 ; ----------------------------------------------------------------------------
 [compiler]
 runCommand="\"<$file>\" <$param>"
 path=C:\\Users\\Albert\\Developer\\FreeBASIC\\fbc.exe
 compileCommand="\"<$fbc>\" \"<$file>\" -s console"
+terminal="x-terminal-emulator -e"
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/ide/config_macos.ini
+++ b/resources/ide/config_macos.ini
@@ -68,13 +68,18 @@ eolMode=LF
 ; Compiler invocation templates.
 ;   <$fbc>       absolute path from `path` below
 ;   <$file>      current source file
-;   <$terminal>  platform default terminal
+;   <$terminal>  launcher prefix that runs the program in a new
+;                terminal window (cmd.exe / x-terminal-emulator -e / ...)
 ;   <$param>     program arguments (Parameters dialog)
 ; ----------------------------------------------------------------------------
 [compiler]
 runCommand="\"<$file>\" <$param>"
 path=
 compileCommand="\"<$fbc>\" \"<$file>\" -s console"
+; macOS Terminal.app does not accept commands as CLI args; launching via
+; `<$terminal>` substitution requires AppleScript or a temp `.command`
+; script. Leave empty until proper macOS terminal launching is implemented.
+terminal=
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/ide/locales/en.ini
+++ b/resources/ide/locales/en.ini
@@ -415,6 +415,11 @@ selectHelpFile=Select help file
 compilerPathError=Compiler path is not set or is corrupt!
 browse=...
 
+[dialogs/settings/compiler/placeholders]
+title=Placeholders (click to insert)
+placeholder=Placeholder
+expansion=Expansion
+
 ; ============================================================================
 ; Find / Replace / Goto line dialogs
 ; ============================================================================

--- a/resources/pristine/config_linux.ini
+++ b/resources/pristine/config_linux.ini
@@ -62,13 +62,15 @@ transformKeywords=1
 ; Compiler invocation templates.
 ;   <$fbc>       absolute path from `path` below
 ;   <$file>      current source file
-;   <$terminal>  platform default terminal
+;   <$terminal>  launcher prefix that runs the program in a new
+;                terminal window (cmd.exe / x-terminal-emulator -e / ...)
 ;   <$param>     program arguments (Parameters dialog)
 ; ----------------------------------------------------------------------------
 [compiler]
 path=
 runCommand="\"<$file>\" <$param>"
 compileCommand="<$terminal> \"<$fbc>\" \"<$file>\""
+terminal="x-terminal-emulator -e"
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/pristine/config_macos.ini
+++ b/resources/pristine/config_macos.ini
@@ -59,13 +59,18 @@ eolMode=LF
 ; Compiler invocation templates.
 ;   <$fbc>       absolute path from `path` below
 ;   <$file>      current source file
-;   <$terminal>  platform default terminal
+;   <$terminal>  launcher prefix that runs the program in a new
+;                terminal window (cmd.exe / x-terminal-emulator -e / ...)
 ;   <$param>     program arguments (Parameters dialog)
 ; ----------------------------------------------------------------------------
 [compiler]
 runCommand="\"<$file>\" <$param>"
 path=
 compileCommand="<$terminal> \"<$fbc>\" \"<$file>\""
+; macOS Terminal.app does not accept commands as CLI args; launching via
+; `<$terminal>` substitution requires AppleScript or a temp `.command`
+; script. Leave empty until proper macOS terminal launching is implemented.
+terminal=
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/pristine/config_win.ini
+++ b/resources/pristine/config_win.ini
@@ -61,13 +61,15 @@ transformKeywords=1
 ; Compiler invocation templates.
 ;   <$fbc>       absolute path from `path` below
 ;   <$file>      current source file
-;   <$terminal>  platform default terminal
+;   <$terminal>  launcher prefix that runs the program in a new
+;                terminal window (cmd.exe / x-terminal-emulator -e / ...)
 ;   <$param>     program arguments (Parameters dialog)
 ; ----------------------------------------------------------------------------
 [compiler]
 path=
 runCommand="\"<$file>\" <$param>"
 compileCommand="\"<$fbc>\" \"<$file>\" -s console"
+terminal="cmd /C"
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/src/lib/compiler/RunCommand.cpp
+++ b/src/lib/compiler/RunCommand.cpp
@@ -18,7 +18,7 @@ auto RunCommand::build(Context& ctx) const -> wxString {
     );
     return build(
         runTemplate,
-        ConfigManager::getTerminal(),
+        ctx.getConfigManager().getTerminalLauncher(),
         ctx.getCompilerManager().getParameters()
     );
 }

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -199,6 +199,31 @@ auto ConfigManager::getTerminal() -> wxString {
 #endif
 }
 
+auto ConfigManager::getTerminalLauncher() -> wxString {
+    return config().get_or("compiler.terminal", getDefaultTerminalLauncher());
+}
+
+auto ConfigManager::getDefaultTerminalLauncher() -> wxString {
+#ifdef __WXMSW__
+    // `cmd /C` runs the program in a new console window allocated by
+    // Windows. Console closes when the program exits — add `& pause` or
+    // a SLEEP at the end of your program if you need to inspect output.
+    // Keeping cmd in the foreground (no `start`) means kill / Stop
+    // cascades through cmd's process group to the child program.
+    return "cmd /C";
+#elif defined(__WXOSX__)
+    // TODO: Terminal.app does not accept the program as a CLI argument;
+    // launching requires AppleScript via `osascript` or a temp `.command`
+    // script. Cannot be expressed as a single-line template prefix.
+    return "";
+#else
+    // `-e` is the de facto flag accepted by the Debian/Ubuntu alternatives
+    // symlink. Distro-specific terminals (gnome-terminal `--`, konsole `-e`)
+    // may need a custom run-command template.
+    return "x-terminal-emulator -e";
+#endif
+}
+
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -78,8 +78,19 @@ public:
     /// Platform default config file name.
     [[nodiscard]] static auto getPlatformConfigFileName() -> wxString;
 
-    /// Platform default terminal command (for running programs).
+    /// Platform default terminal command — opens a bare terminal window
+    /// with no program inside (used by the "Open command prompt" action).
     [[nodiscard]] static auto getTerminal() -> wxString;
+
+    /// Terminal launcher prefix for `<$terminal>` substitution in the run
+    /// command. Reads `compiler.terminal` from config; falls back to a
+    /// platform default. Empty on platforms where the launcher cannot be
+    /// expressed as a command-line prefix (currently macOS).
+    [[nodiscard]] auto getTerminalLauncher() -> wxString;
+
+    /// Platform default for `compiler.terminal` — used when the config
+    /// key is missing or empty.
+    [[nodiscard]] static auto getDefaultTerminalLauncher() -> wxString;
 
     // -----------------------------------------------------------------------
     // Init

--- a/src/lib/settings/panels/CompilerPage.cpp
+++ b/src/lib/settings/panels/CompilerPage.cpp
@@ -8,6 +8,8 @@
 #include "app/Context.hpp"
 #include "compiler/CompilerManager.hpp"
 #include "config/ConfigManager.hpp"
+#include "document/Document.hpp"
+#include "document/DocumentManager.hpp"
 #include "help/HelpManager.hpp"
 using namespace fbide;
 
@@ -24,7 +26,7 @@ CompilerPage::CompilerPage(Context& ctx, wxWindow* parent)
 }
 
 void CompilerPage::create() {
-    vbox(tr("dialogs.settings.compiler.compilerAndPaths"), { .border = 0 }, [&] {
+    vbox(tr("dialogs.settings.compiler.compilerAndPaths"), { .proportion = 1, .border = 0 }, [&] {
         compilerPath();
         spacer();
         compilerCommand();
@@ -34,6 +36,8 @@ void CompilerPage::create() {
         spacer();
         helpFile();
 #endif
+        spacer();
+        placeholderTable();
     });
     SetSizerAndFit(currentSizer());
 }
@@ -56,6 +60,10 @@ void CompilerPage::apply() {
 void CompilerPage::compilerPath() {
     const auto [tf, btn] = makeFileEntry(m_compilerPath, tr("dialogs.settings.compiler.compilerPath"));
     m_compilerPathField = tf;
+    tf->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent& evt) {
+        setPlaceholderVisible(false);
+        evt.Skip();
+    });
     btn->Bind(wxEVT_BUTTON, [&, tf](wxCommandEvent&) {
         wxFileDialog dlg(
             this, "Select compiler", "", "",
@@ -77,16 +85,32 @@ void CompilerPage::focusCompilerPath() {
 }
 
 void CompilerPage::compilerCommand() {
-    makeEntryField(m_compileCommand, tr("dialogs.settings.compiler.compilerCommand"));
+    m_compileCommandField = makeEntryField(m_compileCommand, tr("dialogs.settings.compiler.compilerCommand"));
+    m_compileCommandField->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent& evt) {
+        m_lastFocused = m_compileCommandField;
+        setPlaceholderVisible(true);
+        refreshPlaceholders();
+        evt.Skip();
+    });
 }
 
 void CompilerPage::runCommand() {
-    makeEntryField(m_runCommand, tr("dialogs.settings.compiler.runCommand"));
+    m_runCommandField = makeEntryField(m_runCommand, tr("dialogs.settings.compiler.runCommand"));
+    m_runCommandField->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent& evt) {
+        m_lastFocused = m_runCommandField;
+        setPlaceholderVisible(true);
+        refreshPlaceholders();
+        evt.Skip();
+    });
 }
 
 #ifdef __WXMSW__
 void CompilerPage::helpFile() {
     const auto [tf, btn] = makeFileEntry(m_helpFile, tr("dialogs.settings.compiler.helpFile"));
+    tf->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent& evt) {
+        setPlaceholderVisible(false);
+        evt.Skip();
+    });
     btn->Bind(wxEVT_BUTTON, [&, tf](wxCommandEvent&) {
         wxFileDialog dlg(
             this, "Select help file", "", "",
@@ -101,6 +125,135 @@ void CompilerPage::helpFile() {
     });
 }
 #endif
+
+void CompilerPage::placeholderTable() {
+    const auto trOr = [this](const wxString& key, const wxString& fallback) {
+        const auto val = tr(key);
+        return val.empty() ? fallback : val;
+    };
+
+    m_placeholderTitle = text(trOr("dialogs.settings.compiler.placeholders.title", "Placeholders (click to insert)"), {});
+    const auto list = make_unowned<wxListCtrl>(
+        currentParent(), wxID_ANY,
+        wxDefaultPosition, wxDefaultSize,
+        wxLC_REPORT | wxLC_SINGLE_SEL
+    );
+    list->AppendColumn(trOr("dialogs.settings.compiler.placeholders.placeholder", "Placeholder"), wxLIST_FORMAT_LEFT, 120);
+    list->AppendColumn(trOr("dialogs.settings.compiler.placeholders.expansion", "Expansion"), wxLIST_FORMAT_LEFT, 400);
+    list->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) {
+        int flags = 0;
+        const long item = m_placeholderList->HitTest(evt.GetPosition(), flags);
+        if (item != wxNOT_FOUND && (flags & wxLIST_HITTEST_ONITEM) != 0) {
+            wxListItem info;
+            info.SetId(item);
+            info.SetColumn(0);
+            info.SetMask(wxLIST_MASK_TEXT);
+            m_placeholderList->GetItem(info);
+            insertPlaceholder(info.GetText());
+            return; // do not Skip — default handler would steal focus to the list
+        }
+        evt.Skip();
+    });
+    list->Bind(wxEVT_SIZE, [list](wxSizeEvent& evt) {
+        const int total = list->GetClientSize().GetWidth();
+        const int col0 = list->GetColumnWidth(0);
+        constexpr int padding = 4;
+        const int col1 = std::max(100, total - col0 - padding);
+        list->SetColumnWidth(1, col1);
+        evt.Skip();
+    });
+    add(list, { .proportion = 1 });
+    m_placeholderList = list;
+    m_lastFocused = m_runCommandField;
+    refreshPlaceholders();
+}
+
+void CompilerPage::setPlaceholderVisible(const bool visible) {
+    if (m_placeholderList == nullptr || m_placeholderTitle == nullptr) {
+        return;
+    }
+    if (m_placeholderList->IsShown() == visible) {
+        return;
+    }
+    m_placeholderTitle->Show(visible);
+    m_placeholderList->Show(visible);
+    Layout();
+}
+
+void CompilerPage::refreshPlaceholders() {
+    if (m_placeholderList == nullptr) {
+        return;
+    }
+    m_placeholderList->DeleteAllItems();
+
+    auto append = [this](const wxString& key, const wxString& value) {
+        const auto idx = m_placeholderList->InsertItem(m_placeholderList->GetItemCount(), key);
+        m_placeholderList->SetItem(idx, 1, value);
+    };
+
+    const wxString source = getSampleSourcePath();
+    const bool isRunContext = (m_lastFocused == m_runCommandField);
+
+    if (isRunContext) {
+        wxFileName exe(source);
+        const auto ext = exe.GetExt().Lower();
+        if (ext == "bas" || ext == "bi") {
+#ifdef __WXMSW__
+            exe.SetExt("exe");
+#else
+            exe.SetExt("");
+#endif
+        }
+        append("<$file>", exe.GetFullPath());
+        append("<$file_path>", exe.GetPath());
+        append("<$file_name>", exe.GetName());
+        append("<$file_ext>", exe.GetExt());
+        append("<$param>", getContext().getCompilerManager().getParameters());
+        append("<$terminal>", getContext().getConfigManager().getTerminalLauncher());
+    } else {
+        wxString fbc = m_compilerPath;
+        if (fbc.empty()) {
+#ifdef __WXMSW__
+            fbc = "C:\\path\\to\\fbc.exe";
+#else
+            fbc = "/path/to/fbc";
+#endif
+        }
+        append("<$fbc>", fbc);
+        append("<$file>", source);
+    }
+}
+
+void CompilerPage::insertPlaceholder(const wxString& placeholder) {
+    if (m_lastFocused == nullptr) {
+        return;
+    }
+    m_lastFocused->WriteText(placeholder);
+    // Defer focus restore: native mouse-down on the list may set focus to
+    // the list after our handler returns, so re-focus the text field on
+    // the next event-loop tick to win the race.
+    auto* target = m_lastFocused;
+    CallAfter([target] {
+        if (target != nullptr) {
+            target->SetFocus();
+        }
+    });
+}
+
+auto CompilerPage::getSampleSourcePath() const -> wxString {
+    if (auto* doc = getContext().getDocumentManager().getActive(); doc != nullptr && !doc->isNew()) {
+        const auto& path = doc->getFilePath();
+        const auto ext = wxFileName(path).GetExt().Lower();
+        if (ext == "bas" || ext == "bi") {
+            return path;
+        }
+    }
+#ifdef __WXMSW__
+    return R"(C:\path\to\example.bas)";
+#else
+    return "/path/to/example.bas";
+#endif
+}
 
 auto CompilerPage::makeEntryField(wxString& value, const wxString& labelText) -> Unowned<wxTextCtrl> {
     const auto lbl = text(labelText, {});

--- a/src/lib/settings/panels/CompilerPage.hpp
+++ b/src/lib/settings/panels/CompilerPage.hpp
@@ -44,6 +44,16 @@ private:
     /// Build the CHM help-file path picker row (Windows only).
     void helpFile();
 #endif
+    /// Build the placeholder reference list (click-to-insert).
+    void placeholderTable();
+    /// Repopulate the placeholder list for the currently-focused command field.
+    void refreshPlaceholders();
+    /// Insert `placeholder` at the cursor of the most recently focused command field.
+    void insertPlaceholder(const wxString& placeholder);
+    /// Show or hide the placeholder list + its title in unison.
+    void setPlaceholderVisible(bool visible);
+    /// Path used as `<$file>` example — active FB document if any, otherwise a fixed sample.
+    [[nodiscard]] auto getSampleSourcePath() const -> wxString;
 
     /// Create a labelled text-entry field bound to `value`.
     auto makeEntryField(wxString& value, const wxString& labelText) -> Unowned<wxTextCtrl>;
@@ -56,7 +66,12 @@ private:
 #ifdef __WXMSW__
     wxString m_helpFile;         ///< CHM help-file path (Windows only).
 #endif
-    Unowned<wxTextCtrl> m_compilerPathField {}; ///< Cached compiler-path entry for `focusCompilerPath`.
+    Unowned<wxTextCtrl> m_compilerPathField {};   ///< Cached compiler-path entry for `focusCompilerPath`.
+    Unowned<wxTextCtrl> m_compileCommandField {}; ///< Cached compile-command entry (target of placeholder inserts).
+    Unowned<wxTextCtrl> m_runCommandField {};     ///< Cached run-command entry (target of placeholder inserts).
+    Unowned<wxStaticText> m_placeholderTitle {};  ///< Heading shown above `m_placeholderList`; hidden together.
+    Unowned<wxListCtrl> m_placeholderList {};     ///< Click-to-insert placeholder reference table.
+    wxTextCtrl* m_lastFocused = nullptr;          ///< Most recently focused command field (insert target).
 };
 
 } // namespace fbide


### PR DESCRIPTION
Add `compiler.terminal` config key driving `<$terminal>` substitution, with platform-default launcher prefix (Win: `cmd /C`, Linux: `x-terminal-emulator -e`, macOS empty pending AppleScript wrapper). Cmd-based form keeps target in cmd's process group so Stop cascades.

Add click-to-insert placeholder reference table to the Compiler settings tab. Examples adjust per focused command field, table hides for path/help-file fields, expansion column auto-sizes, list grows vertically with the dialog. Insert restores focus to the text field.

closes #45 