### PR TITLE
Add live filter search box to the symbol browser

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -8,6 +8,7 @@
 - Changed symbol browser to show the qualified name for methods (`Type.Method`)
 - Added constructors, destructors, operators and properties to the symbol browser
 - Changed symbol browser to group UDT methods (subs, functions, constructors, …) under their owning type
+- Added a search box to the symbol browser to filter results live by name, symbol type or UDT
 
 # Changes since 0.5.0-beta.3
 

--- a/resources/ide/locales/de.ini
+++ b/resources/ide/locales/de.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Enums
 macros=Makros
 includes=Includes
+searchHint=Symbole filtern
 
 [tabContext]
 closeOthers=Andere schließen

--- a/resources/ide/locales/el.ini
+++ b/resources/ide/locales/el.ini
@@ -478,6 +478,7 @@ unions=Ενώσεις
 enums=Απαριθμήσεις
 macros=Μακροεντολές
 includes=Includes
+searchHint=Φιλτράρισμα συμβόλων
 
 [tabContext]
 closeOthers=Κλείσιμο των άλλων

--- a/resources/ide/locales/en.ini
+++ b/resources/ide/locales/en.ini
@@ -504,6 +504,7 @@ unions=Unions
 enums=Enums
 macros=Macros
 includes=Includes
+searchHint=Filter symbols
 
 [tabContext]
 closeOthers=Close Others

--- a/resources/ide/locales/es.ini
+++ b/resources/ide/locales/es.ini
@@ -492,6 +492,7 @@ unions=Unions
 enums=Enums
 macros=Macros
 includes=Includes
+searchHint=Filter symbols
 
 [tabContext]
 closeOthers=Cerrar el resto

--- a/resources/ide/locales/et.ini
+++ b/resources/ide/locales/et.ini
@@ -474,6 +474,7 @@ unions=Ühisalad
 enums=Loendid
 macros=Makrod
 includes=Päised
+searchHint=Filtreeri sümboleid
 
 [tabContext]
 closeOthers=Sulge teised

--- a/resources/ide/locales/fi.ini
+++ b/resources/ide/locales/fi.ini
@@ -478,6 +478,7 @@ unions=Uniot
 enums=Enumeraatiot
 macros=Makrot
 includes=Sisällytykset
+searchHint=Suodata symboleja
 
 [tabContext]
 closeOthers=Sulje muut

--- a/resources/ide/locales/fr.ini
+++ b/resources/ide/locales/fr.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Énumérations
 macros=Macros
 includes=Inclusions
+searchHint=Filtrer les symboles
 
 [tabContext]
 closeOthers=Fermer les autres

--- a/resources/ide/locales/ja.ini
+++ b/resources/ide/locales/ja.ini
@@ -478,6 +478,7 @@ unions=共用体
 enums=列挙体
 macros=マクロ
 includes=インクルード
+searchHint=シンボルを絞り込み
 
 [tabContext]
 closeOthers=他を閉じる

--- a/resources/ide/locales/nl.ini
+++ b/resources/ide/locales/nl.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Enums
 macros=Macro's
 includes=Includes
+searchHint=Symbolen filteren
 
 [tabContext]
 closeOthers=Andere sluiten

--- a/resources/ide/locales/pt.ini
+++ b/resources/ide/locales/pt.ini
@@ -478,6 +478,7 @@ unions=Uniões
 enums=Enumerações
 macros=Macros
 includes=Includes
+searchHint=Filtrar símbolos
 
 [tabContext]
 closeOthers=Fechar outros

--- a/resources/ide/locales/ro.ini
+++ b/resources/ide/locales/ro.ini
@@ -478,6 +478,7 @@ unions=Uniuni
 enums=Enumerări
 macros=Macrouri
 includes=Include-uri
+searchHint=Filtrează simbolurile
 
 [tabContext]
 closeOthers=Închide celelalte

--- a/resources/ide/locales/ru.ini
+++ b/resources/ide/locales/ru.ini
@@ -478,6 +478,7 @@ unions=Объединения
 enums=Перечисления
 macros=Макросы
 includes=Includes
+searchHint=Фильтр символов
 
 [tabContext]
 closeOthers=Закрыть остальные

--- a/resources/ide/locales/sk.ini
+++ b/resources/ide/locales/sk.ini
@@ -478,6 +478,7 @@ unions=Únie
 enums=Enumerácie
 macros=Makrá
 includes=Includes
+searchHint=Filtrovať symboly
 
 [tabContext]
 closeOthers=Zavrieť ostatné

--- a/resources/ide/locales/zh.ini
+++ b/resources/ide/locales/zh.ini
@@ -478,6 +478,7 @@ unions=联合体
 enums=枚举
 macros=宏
 includes=包含文件
+searchHint=筛选符号
 
 [tabContext]
 closeOthers=关闭其他

--- a/resources/pristine/locales/de.ini
+++ b/resources/pristine/locales/de.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Enums
 macros=Makros
 includes=Includes
+searchHint=Symbole filtern
 
 [tabContext]
 closeOthers=Andere schließen

--- a/resources/pristine/locales/el.ini
+++ b/resources/pristine/locales/el.ini
@@ -478,6 +478,7 @@ unions=Ενώσεις
 enums=Απαριθμήσεις
 macros=Μακροεντολές
 includes=Includes
+searchHint=Φιλτράρισμα συμβόλων
 
 [tabContext]
 closeOthers=Κλείσιμο των άλλων

--- a/resources/pristine/locales/en.ini
+++ b/resources/pristine/locales/en.ini
@@ -499,6 +499,7 @@ unions=Unions
 enums=Enums
 macros=Macros
 includes=Includes
+searchHint=Filter symbols
 
 [tabContext]
 closeOthers=Close Others

--- a/resources/pristine/locales/es.ini
+++ b/resources/pristine/locales/es.ini
@@ -492,6 +492,7 @@ unions=Unions
 enums=Enums
 macros=Macros
 includes=Includes
+searchHint=Filter symbols
 
 [tabContext]
 closeOthers=Cerrar el resto

--- a/resources/pristine/locales/et.ini
+++ b/resources/pristine/locales/et.ini
@@ -474,6 +474,7 @@ unions=Ühisalad
 enums=Loendid
 macros=Makrod
 includes=Päised
+searchHint=Filtreeri sümboleid
 
 [tabContext]
 closeOthers=Sulge teised

--- a/resources/pristine/locales/fi.ini
+++ b/resources/pristine/locales/fi.ini
@@ -478,6 +478,7 @@ unions=Uniot
 enums=Enumeraatiot
 macros=Makrot
 includes=Sisällytykset
+searchHint=Suodata symboleja
 
 [tabContext]
 closeOthers=Sulje muut

--- a/resources/pristine/locales/fr.ini
+++ b/resources/pristine/locales/fr.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Énumérations
 macros=Macros
 includes=Inclusions
+searchHint=Filtrer les symboles
 
 [tabContext]
 closeOthers=Fermer les autres

--- a/resources/pristine/locales/ja.ini
+++ b/resources/pristine/locales/ja.ini
@@ -478,6 +478,7 @@ unions=共用体
 enums=列挙体
 macros=マクロ
 includes=インクルード
+searchHint=シンボルを絞り込み
 
 [tabContext]
 closeOthers=他を閉じる

--- a/resources/pristine/locales/nl.ini
+++ b/resources/pristine/locales/nl.ini
@@ -478,6 +478,7 @@ unions=Unions
 enums=Enums
 macros=Macro's
 includes=Includes
+searchHint=Symbolen filteren
 
 [tabContext]
 closeOthers=Andere sluiten

--- a/resources/pristine/locales/pt.ini
+++ b/resources/pristine/locales/pt.ini
@@ -478,6 +478,7 @@ unions=Uniões
 enums=Enumerações
 macros=Macros
 includes=Includes
+searchHint=Filtrar símbolos
 
 [tabContext]
 closeOthers=Fechar outros

--- a/resources/pristine/locales/ro.ini
+++ b/resources/pristine/locales/ro.ini
@@ -478,6 +478,7 @@ unions=Uniuni
 enums=Enumerări
 macros=Macrouri
 includes=Include-uri
+searchHint=Filtrează simbolurile
 
 [tabContext]
 closeOthers=Închide celelalte

--- a/resources/pristine/locales/ru.ini
+++ b/resources/pristine/locales/ru.ini
@@ -478,6 +478,7 @@ unions=Объединения
 enums=Перечисления
 macros=Макросы
 includes=Includes
+searchHint=Фильтр символов
 
 [tabContext]
 closeOthers=Закрыть остальные

--- a/resources/pristine/locales/sk.ini
+++ b/resources/pristine/locales/sk.ini
@@ -478,6 +478,7 @@ unions=Únie
 enums=Enumerácie
 macros=Makrá
 includes=Includes
+searchHint=Filtrovať symboly
 
 [tabContext]
 closeOthers=Zavrieť ostatné

--- a/resources/pristine/locales/zh.ini
+++ b/resources/pristine/locales/zh.ini
@@ -478,6 +478,7 @@ unions=联合体
 enums=枚举
 macros=宏
 includes=包含文件
+searchHint=筛选符号
 
 [tabContext]
 closeOthers=关闭其他

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(fbide_lib
     settings/panels/ThemePage.cpp
     sidebar/SideBarManager.cpp
     sidebar/SymbolBrowser.cpp
+    sidebar/SymbolBrowserPanel.cpp
     ui/ArtiProvider.cpp
     ui/CompilerLog.cpp
     ui/EncodingMenu.cpp
@@ -120,6 +121,7 @@ target_sources(fbide_lib
     settings/panels/ThemePage.hpp
     sidebar/SideBarManager.hpp
     sidebar/SymbolBrowser.hpp
+    sidebar/SymbolBrowserPanel.hpp
     ui/ArtiProvider.hpp
     ui/CompilerLog.hpp
     ui/EncodingMenu.hpp

--- a/src/lib/sidebar/SideBarManager.cpp
+++ b/src/lib/sidebar/SideBarManager.cpp
@@ -6,7 +6,7 @@
 //
 #include "SideBarManager.hpp"
 #include <wx/dirctrl.h>
-#include "SymbolBrowser.hpp"
+#include "SymbolBrowserPanel.hpp"
 #include "app/Context.hpp"
 #include "command/CommandEntry.hpp"
 #include "command/CommandId.hpp"
@@ -32,9 +32,9 @@ void SideBarManager::attach(wxAuiNotebook* notebook) {
 
     // Sub/Function tree tab — first page so it matches the old fbide order
     // (S/F tree → Browse Files).
-    m_symbolBrowser = make_unowned<SymbolBrowser>(m_ctx, m_notebook);
+    m_symbolPanel = make_unowned<SymbolBrowserPanel>(m_ctx, m_notebook);
     m_subFunctionPage = static_cast<int>(m_notebook->GetPageCount());
-    m_notebook->AddPage(m_symbolBrowser, m_ctx.tr("sidebar.tabs.subFunction"));
+    m_notebook->AddPage(m_symbolPanel, m_ctx.tr("sidebar.tabs.subFunction"));
 
     // Browse Files tab.
     m_dirCtrl = make_unowned<wxGenericDirCtrl>(
@@ -73,14 +73,14 @@ void SideBarManager::showSymbolBrowser() {
         entry->setChecked(true);
     }
     m_notebook->SetSelection(static_cast<size_t>(m_subFunctionPage));
-    if (m_symbolBrowser != nullptr) {
-        m_symbolBrowser->SetFocus();
+    if (m_symbolPanel != nullptr) {
+        m_symbolPanel->focusSearch();
     }
 }
 
 void SideBarManager::showSymbolsFor(const Document* doc) {
-    if (m_symbolBrowser != nullptr) {
-        m_symbolBrowser->setSymbols(doc);
+    if (m_symbolPanel != nullptr) {
+        m_symbolPanel->setSymbols(doc);
     }
 }
 

--- a/src/lib/sidebar/SideBarManager.hpp
+++ b/src/lib/sidebar/SideBarManager.hpp
@@ -13,14 +13,14 @@ class wxTreeEvent;
 namespace fbide {
 class Context;
 class Document;
-class SymbolBrowser;
+class SymbolBrowserPanel;
 
 /**
  * Populates the Browser sidebar notebook with tabs (Browse Files,
  * Sub/Function tree) and drives their behaviour.
  *
  * **Owns:** the tab content (wx-parented to the notebook) plus the
- * cached `wxGenericDirCtrl*` and `SymbolBrowser*`.
+ * cached `wxGenericDirCtrl*` and `SymbolBrowserPanel*`.
  * **Owned by:** `Context`. Declared *after* `UIManager` so destruction
  * runs first — its non-owning pointer to the sidebar `wxAuiNotebook`
  * (owned by the frame UIManager destroys) cannot dangle.
@@ -41,7 +41,7 @@ public:
 
     /// Construct without populating tabs; `attach()` does that later.
     explicit SideBarManager(Context& ctx);
-    /// Out-of-line so the destructor sees the full `SymbolBrowser` definition.
+    /// Out-of-line so the destructor sees the full `SymbolBrowserPanel` definition.
     ~SideBarManager() override;
 
     /// Two-phase init: called from `UIManager::createLayout` once the sidebar
@@ -60,21 +60,21 @@ public:
     /// when the same shared_ptr<SymbolTable> is shown twice in a row.
     void showSymbolsFor(const Document* doc);
 
-    /// Reveal the Browser pane (toggling its CommandEntry on if hidden) and
-    /// switch the notebook to the Sub/Function tree tab. Bound to the
-    /// "Show Subs" command (F2).
+    /// Reveal the Browser pane (toggling its CommandEntry on if hidden),
+    /// switch the notebook to the Sub/Function tree tab and focus its filter
+    /// box. Bound to the "Show Subs" command (F2).
     void showSymbolBrowser();
 
 private:
     /// Browse Files tree leaf activated — open the file in a new editor tab.
     void onFileActivated(wxTreeEvent& event);
 
-    Context& m_ctx;                         ///< Application context.
-    wxAuiNotebook* m_notebook = nullptr;    ///< Non-owning pointer into the sidebar notebook (owned by the frame).
-    Unowned<wxGenericDirCtrl> m_dirCtrl;    ///< Browse Files control.
-    Unowned<SymbolBrowser> m_symbolBrowser; ///< Sub/Function tree control.
-    int m_subFunctionPage = wxNOT_FOUND;    ///< Cached page index of the Sub/Function tab.
-    int m_browseFilesPage = wxNOT_FOUND;    ///< Cached page index of the Browse Files tab.
+    Context& m_ctx;                            ///< Application context.
+    wxAuiNotebook* m_notebook = nullptr;       ///< Non-owning pointer into the sidebar notebook (owned by the frame).
+    Unowned<wxGenericDirCtrl> m_dirCtrl;       ///< Browse Files control.
+    Unowned<SymbolBrowserPanel> m_symbolPanel; ///< Sub/Function tab (filter box + tree).
+    int m_subFunctionPage = wxNOT_FOUND;       ///< Cached page index of the Sub/Function tab.
+    int m_browseFilesPage = wxNOT_FOUND;       ///< Cached page index of the Browse Files tab.
 };
 
 } // namespace fbide

--- a/src/lib/sidebar/SymbolBrowser.cpp
+++ b/src/lib/sidebar/SymbolBrowser.cpp
@@ -14,9 +14,93 @@
 #include "ui/UIManager.hpp"
 using namespace fbide;
 
+auto fbide::parseSymbolFilter(const wxString& query) -> std::vector<wxString> {
+    std::vector<wxString> words;
+    wxStringTokenizer tokenizer(query, " \t\r\n", wxTOKEN_STRTOK);
+    while (tokenizer.HasMoreTokens()) {
+        words.push_back(tokenizer.GetNextToken().Lower());
+    }
+    return words;
+}
+
+auto fbide::symbolFilterMatches(const std::vector<wxString>& words, const wxString& haystack) -> bool {
+    return std::ranges::all_of(words, [&](const wxString& word) { return haystack.Contains(word); });
+}
+
 wxBEGIN_EVENT_TABLE(SymbolBrowser, wxTreeCtrl)
     EVT_TREE_ITEM_ACTIVATED(wxID_ANY, SymbolBrowser::onItemActivated)
 wxEND_EVENT_TABLE()
+
+auto SymbolBrowser::kindKeywords(const SymbolKind kind) -> wxString {
+    switch (kind) {
+    case SymbolKind::Sub:
+        return "sub";
+    case SymbolKind::Function:
+        return "function";
+    case SymbolKind::Constructor:
+        return "constructor";
+    case SymbolKind::Destructor:
+        return "destructor";
+    case SymbolKind::Operator:
+        return "operator";
+    case SymbolKind::Property:
+        return "property properties";
+    case SymbolKind::Type:
+        return "type udt";
+    case SymbolKind::Union:
+        return "union";
+    case SymbolKind::Enum:
+        return "enum";
+    case SymbolKind::Macro:
+        return "macro";
+    case SymbolKind::Include:
+        return "include";
+    }
+    return {};
+}
+
+auto SymbolBrowser::kindLocaleLabel(const SymbolKind kind) const -> wxString {
+    switch (kind) {
+    case SymbolKind::Sub:
+        return m_ctx.tr("sidebar.symbols.subs");
+    case SymbolKind::Function:
+        return m_ctx.tr("sidebar.symbols.functions");
+    case SymbolKind::Constructor:
+        return m_ctx.tr("sidebar.symbols.constructors");
+    case SymbolKind::Destructor:
+        return m_ctx.tr("sidebar.symbols.destructors");
+    case SymbolKind::Operator:
+        return m_ctx.tr("sidebar.symbols.operators");
+    case SymbolKind::Property:
+        return m_ctx.tr("sidebar.symbols.properties");
+    case SymbolKind::Type:
+        return m_ctx.tr("sidebar.symbols.types");
+    case SymbolKind::Union:
+        return m_ctx.tr("sidebar.symbols.unions");
+    case SymbolKind::Enum:
+        return m_ctx.tr("sidebar.symbols.enums");
+    case SymbolKind::Macro:
+        return m_ctx.tr("sidebar.symbols.macros");
+    case SymbolKind::Include:
+        return m_ctx.tr("sidebar.symbols.includes");
+    }
+    return {};
+}
+
+auto SymbolBrowser::filterHaystack(const wxString& name, SymbolKind kind) const -> wxString {
+    // Owner-qualified names (`Owner.member`) carry the owning UDT, so a
+    // member also matches when its type name is searched for.
+    wxString haystack = name;
+    haystack << ' ' << kindKeywords(kind) << ' ' << kindLocaleLabel(kind);
+    return haystack.Lower();
+}
+
+auto SymbolBrowser::passesFilter(const wxString& name, SymbolKind kind) const -> bool {
+    if (m_filterWords.empty()) {
+        return true;
+    }
+    return symbolFilterMatches(m_filterWords, filterHaystack(name, kind));
+}
 
 void SymbolBrowser::appendBucket(
     SymbolKind kind,
@@ -25,19 +109,25 @@ void SymbolBrowser::appendBucket(
 ) {
     // Method-qualified symbols are nested under their owning type instead.
     const auto isFreeStanding = [](const Symbol& sym) { return symbolOwner(sym).empty(); };
-    if (std::ranges::none_of(bucket, isFreeStanding)) {
+
+    // Gather the surviving free-standing symbols first so the folder is
+    // only created when at least one leaf passes the filter.
+    std::vector<std::size_t> kept;
+    for (std::size_t idx = 0; idx < bucket.size(); idx++) {
+        const auto& sym = bucket[idx];
+        if (isFreeStanding(sym) && passesFilter(sym.name, kind)) {
+            kept.push_back(idx);
+        }
+    }
+    if (kept.empty()) {
         return;
     }
 
     const auto image = static_cast<int>(kind);
     const auto folder = AppendItem(GetRootItem(), label, image, image);
     SetItemBold(folder, true);
-    for (std::size_t idx = 0; idx < bucket.size(); idx++) {
-        const auto& sym = bucket[idx];
-        if (!isFreeStanding(sym)) {
-            continue;
-        }
-        const auto id = AppendItem(folder, sym.name, image, image, nullptr);
+    for (const auto idx : kept) {
+        const auto id = AppendItem(folder, bucket[idx].name, image, image, nullptr);
         m_entries[id.GetID()] = { .kind = kind, .index = idx };
     }
     Expand(folder);
@@ -62,8 +152,6 @@ void SymbolBrowser::appendTypeTree(const wxString& label) {
     }
 
     constexpr auto typeImage = static_cast<int>(SymbolKind::Type);
-    const auto folder = AppendItem(GetRootItem(), label, typeImage, typeImage);
-    SetItemBold(folder, true);
 
     // One nested member, paired with the flat-vector slot it navigates to.
     struct Member {
@@ -72,26 +160,34 @@ void SymbolBrowser::appendTypeTree(const wxString& label) {
         int line;
         wxString label;
     };
+    // A type that survived the filter, paired with its surviving members.
+    struct TypeNode {
+        std::size_t typeIdx;
+        std::vector<Member> members;
+    };
 
+    std::vector<TypeNode> kept;
     for (std::size_t typeIdx = 0; typeIdx < types.size(); typeIdx++) {
         const auto& type = types[typeIdx];
-        const auto node = AppendItem(folder, type.name, typeImage, typeImage);
-        // A declared type navigates to its source line; a synthetic owner
-        // (negative line) is a group header only.
-        if (type.line >= 0) {
-            m_entries[node.GetID()] = { .kind = SymbolKind::Type, .index = typeIdx };
-        }
+        // A matching UDT pulls in all of its members; otherwise each member
+        // must match the filter on its own.
+        const bool typePasses = passesFilter(type.name, SymbolKind::Type);
 
         // Gather every member owned by this type, across all callable kinds.
         std::vector<Member> members;
-        const auto gather = [&](const SymbolKind kind, const std::vector<Symbol>& bucket) {
+        const auto gather = [&](SymbolKind kind, const std::vector<Symbol>& bucket) {
             for (std::size_t idx = 0; idx < bucket.size(); idx++) {
-                if (symbolOwner(bucket[idx]) == type.name) {
-                    members.push_back({ .kind = kind,
-                        .index = idx,
-                        .line = bucket[idx].line,
-                        .label = memberLabel(bucket[idx]) });
+                const auto& sym = bucket[idx];
+                if (symbolOwner(sym) != type.name) {
+                    continue;
                 }
+                if (!typePasses && !passesFilter(sym.name, kind)) {
+                    continue;
+                }
+                members.push_back({ .kind = kind,
+                    .index = idx,
+                    .line = sym.line,
+                    .label = memberLabel(sym) });
             }
         };
         gather(SymbolKind::Sub, m_currentTable->getSubs());
@@ -101,9 +197,28 @@ void SymbolBrowser::appendTypeTree(const wxString& label) {
         gather(SymbolKind::Operator, m_currentTable->getOperators());
         gather(SymbolKind::Property, m_currentTable->getProperties());
 
+        if (!typePasses && members.empty()) {
+            continue;
+        }
         // Source order — members come from per-kind vectors, so sort by line.
         std::ranges::sort(members, {}, &Member::line);
-        for (const auto& member : members) {
+        kept.push_back({ .typeIdx = typeIdx, .members = std::move(members) });
+    }
+    if (kept.empty()) {
+        return;
+    }
+
+    const auto folder = AppendItem(GetRootItem(), label, typeImage, typeImage);
+    SetItemBold(folder, true);
+    for (const auto& typeNode : kept) {
+        const auto& type = types[typeNode.typeIdx];
+        const auto node = AppendItem(folder, type.name, typeImage, typeImage);
+        // A declared type navigates to its source line; a synthetic owner
+        // (negative line) is a group header only.
+        if (type.line >= 0) {
+            m_entries[node.GetID()] = { .kind = SymbolKind::Type, .index = typeNode.typeIdx };
+        }
+        for (const auto& member : typeNode.members) {
             const auto image = static_cast<int>(member.kind);
             const auto leaf = AppendItem(node, member.label, image, image, nullptr);
             m_entries[leaf.GetID()] = { .kind = member.kind, .index = member.index };
@@ -117,16 +232,21 @@ void SymbolBrowser::appendIncludes(
     const wxString& label,
     const std::vector<Include>& includes
 ) {
-    if (includes.empty()) {
+    std::vector<std::size_t> kept;
+    for (std::size_t idx = 0; idx < includes.size(); idx++) {
+        if (passesFilter(includes[idx].path, SymbolKind::Include)) {
+            kept.push_back(idx);
+        }
+    }
+    if (kept.empty()) {
         return;
     }
 
     constexpr auto image = static_cast<int>(SymbolKind::Include);
     const auto folder = AppendItem(GetRootItem(), label, image, image);
     SetItemBold(folder, true);
-    for (std::size_t idx = 0; idx < includes.size(); idx++) {
-        const auto& inc = includes[idx];
-        const auto id = AppendItem(folder, inc.path, image, image, nullptr);
+    for (const auto idx : kept) {
+        const auto id = AppendItem(folder, includes[idx].path, image, image, nullptr);
         m_entries[id.GetID()] = { .kind = SymbolKind::Include, .index = idx };
     }
     Expand(folder);
@@ -178,6 +298,17 @@ void SymbolBrowser::setSymbols(const Document* doc) {
     if (table == nullptr) {
         clearTree();
     } else if (old == nullptr || old->getHash() != table->getHash()) {
+        rebuild();
+    }
+}
+
+void SymbolBrowser::setFilter(const wxString& query) {
+    auto words = parseSymbolFilter(query);
+    if (words == m_filterWords) {
+        return;
+    }
+    m_filterWords = std::move(words);
+    if (m_currentTable != nullptr) {
         rebuild();
     }
 }

--- a/src/lib/sidebar/SymbolBrowser.hpp
+++ b/src/lib/sidebar/SymbolBrowser.hpp
@@ -12,11 +12,20 @@ namespace fbide {
 class Context;
 class Document;
 
+/// Split a raw search query into lowercased, non-empty filter words.
+/// Whitespace-delimited; an all-blank query yields an empty list.
+[[nodiscard]] auto parseSymbolFilter(const wxString& query) -> std::vector<wxString>;
+
+/// True when every word in `words` is a substring of `haystack`. Both
+/// `words` and `haystack` must already be lowercased. An empty `words`
+/// list matches anything.
+[[nodiscard]] auto symbolFilterMatches(const std::vector<wxString>& words, const wxString& haystack) -> bool;
+
 /**
  * Sub/Function tree tab — a `wxTreeCtrl` subclass parented to the
- * sidebar notebook. Renders a `Document`'s `SymbolTable`; activating
- * a leaf jumps the active editor to that line and scrolls it to the
- * top of the viewport.
+ * sidebar notebook (inside `SymbolBrowserPanel`). Renders a
+ * `Document`'s `SymbolTable`; activating a leaf jumps the active
+ * editor to that line and scrolls it to the top of the viewport.
  *
  * Subclassing the control directly (rather than `PushEventHandler`)
  * means the static event table dispatches without an extra handler
@@ -40,6 +49,11 @@ public:
     /// hash matches — line-only edits don't visually change the listing.
     void setSymbols(const Document* doc);
 
+    /// Apply a live filter query. Parses `query` into words and rebuilds
+    /// the tree showing only matching entries. An empty/blank query shows
+    /// everything. No-op when the parsed words are unchanged.
+    void setFilter(const wxString& query);
+
 private:
     /// Per-leaf lookup payload. `kind` selects which `SymbolTable` vector
     /// to read, `index` is the offset into that vector.
@@ -55,11 +69,28 @@ private:
     /// Clear the tree and `m_entries`.
     void clearTree();
 
-    /// Append a folder + leaves under the tree root when the bucket holds at
-    /// least one free-standing symbol. Method-qualified symbols are skipped —
-    /// they are grouped under their owning type by `appendTypeTree`. Each leaf
-    /// registers an `Entry` in `m_entries` keyed by its tree id.
+    /// Append a folder + leaves under the tree root for every free-standing
+    /// symbol in `bucket` that passes the current filter. Method-qualified
+    /// symbols are skipped — they are grouped under their owning type by
+    /// `appendTypeTree`. The folder is omitted when nothing survives. Each
+    /// leaf registers an `Entry` in `m_entries` keyed by its tree id.
     void appendBucket(SymbolKind kind, const wxString& label, const std::vector<Symbol>& bucket);
+
+    /// English keyword synonyms for a kind (e.g. `Type` → "type udt"),
+    /// space-joined and lowercased — part of a leaf's filter haystack.
+    [[nodiscard]] static auto kindKeywords(SymbolKind kind) -> wxString;
+
+    /// Localised group label for a kind (the `sidebar.symbols.*` string) —
+    /// the locale-specific half of a leaf's filter haystack.
+    [[nodiscard]] auto kindLocaleLabel(SymbolKind kind) const -> wxString;
+
+    /// Build the lowercased filter haystack for one entry: its (possibly
+    /// owner-qualified) `name` plus the kind's english + localised words.
+    [[nodiscard]] auto filterHaystack(const wxString& name, SymbolKind kind) const -> wxString;
+
+    /// True when `name`/`kind` passes the current filter (always true when
+    /// no filter is set).
+    [[nodiscard]] auto passesFilter(const wxString& name, SymbolKind kind) const -> bool;
 
     /// Append the Types folder: each declared or synthesised type, with its
     /// method members (subs, functions, constructors, …) nested beneath it.
@@ -81,6 +112,7 @@ private:
 
     Context& m_ctx;                                    ///< Application context.
     std::shared_ptr<const SymbolTable> m_currentTable; ///< Currently rendered symbol table.
+    std::vector<wxString> m_filterWords;               ///< Active filter words (lowercased); empty = no filter.
 
     /// Tree id → entry payload. Rebuilt in `rebuild`, cleared in `clearTree`.
     /// `wxTreeItemId::Type` is the underlying void* the control hands out.

--- a/src/lib/sidebar/SymbolBrowserPanel.cpp
+++ b/src/lib/sidebar/SymbolBrowserPanel.cpp
@@ -1,0 +1,51 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include "SymbolBrowserPanel.hpp"
+#include <wx/srchctrl.h>
+#include "SymbolBrowser.hpp"
+#include "app/Context.hpp"
+using namespace fbide;
+
+SymbolBrowserPanel::SymbolBrowserPanel(Context& ctx, wxWindow* parent)
+: wxPanel(parent, wxID_ANY)
+, m_ctx(ctx) {
+    m_search = make_unowned<wxSearchCtrl>(
+        this, wxID_ANY, wxEmptyString,
+        wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER
+    );
+    m_search->ShowSearchButton(true);
+    m_search->ShowCancelButton(true);
+    m_search->SetDescriptiveText(m_ctx.tr("sidebar.symbols.searchHint"));
+
+    m_tree = make_unowned<SymbolBrowser>(m_ctx, this);
+
+    const auto sizer = make_unowned<wxBoxSizer>(wxVERTICAL);
+    sizer->Add(m_search, 0, wxEXPAND | wxALL, 2);
+    sizer->Add(m_tree, 1, wxEXPAND);
+    SetSizer(sizer);
+
+    // Real-time filtering: wxEVT_TEXT fires on every keystroke; the search
+    // and cancel buttons route through the same handler. The cancel button
+    // only clears the box — the resulting wxEVT_TEXT empties the filter.
+    m_search->Bind(wxEVT_TEXT, &SymbolBrowserPanel::onSearch, this);
+    m_search->Bind(wxEVT_SEARCH, &SymbolBrowserPanel::onSearch, this);
+    m_search->Bind(wxEVT_SEARCH_CANCEL, [this](wxCommandEvent&) { m_search->Clear(); });
+}
+
+SymbolBrowserPanel::~SymbolBrowserPanel() = default;
+
+void SymbolBrowserPanel::setSymbols(const Document* doc) {
+    m_tree->setSymbols(doc);
+}
+
+void SymbolBrowserPanel::focusSearch() {
+    m_search->SetFocus();
+}
+
+void SymbolBrowserPanel::onSearch(wxCommandEvent& /*event*/) {
+    m_tree->setFilter(m_search->GetValue());
+}

--- a/src/lib/sidebar/SymbolBrowserPanel.hpp
+++ b/src/lib/sidebar/SymbolBrowserPanel.hpp
@@ -1,0 +1,54 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#pragma once
+#include "pch.hpp"
+
+class wxSearchCtrl;
+class wxCommandEvent;
+
+namespace fbide {
+class Context;
+class Document;
+class SymbolBrowser;
+
+/**
+ * Sub/Function sidebar tab: a live filter box stacked above the
+ * `SymbolBrowser` tree. Typing in the box filters the tree in real
+ * time; this panel is the notebook page, the tree is its child.
+ *
+ * **Owns:** the `wxSearchCtrl` and `SymbolBrowser` (both wx-parented
+ * to this panel). **Owned by:** `SideBarManager` (wx-parented to the
+ * sidebar notebook).
+ *
+ * See @ref ui and @ref architecture.
+ */
+class SymbolBrowserPanel final : public wxPanel {
+public:
+    NO_COPY_AND_MOVE(SymbolBrowserPanel)
+
+    /// Construct, parented to the sidebar notebook.
+    SymbolBrowserPanel(Context& ctx, wxWindow* parent);
+    /// Out-of-line so the destructor sees the full `SymbolBrowser` definition.
+    ~SymbolBrowserPanel() override;
+
+    /// Forward to the embedded tree — see `SymbolBrowser::setSymbols`.
+    void setSymbols(const Document* doc);
+
+    /// Focus the filter box, so the tab opens ready for filter-as-you-type.
+    void focusSearch();
+
+private:
+    /// Search box changed (typing, search button or cancel) — push the
+    /// current query into the tree filter.
+    void onSearch(wxCommandEvent& event);
+
+    Context& m_ctx;                   ///< Application context.
+    Unowned<wxSearchCtrl> m_search;   ///< Live filter input.
+    Unowned<SymbolBrowser> m_tree;    ///< Symbol tree.
+};
+
+} // namespace fbide

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(tests
     unit/ReFormatterTests.cpp
     unit/StyleLexerTests.cpp
     unit/RunCommandTests.cpp
+    unit/SymbolBrowserFilterTests.cpp
     unit/SymbolTableTests.cpp
     unit/TextEncodingTests.cpp
     unit/ThemeTests.cpp

--- a/tests/unit/SymbolBrowserFilterTests.cpp
+++ b/tests/unit/SymbolBrowserFilterTests.cpp
@@ -1,0 +1,42 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include <gtest/gtest.h>
+#include "sidebar/SymbolBrowser.hpp"
+
+using namespace fbide;
+
+TEST(SymbolBrowserFilterTests, ParseBlankYieldsNoWords) {
+    EXPECT_TRUE(parseSymbolFilter("").empty());
+    EXPECT_TRUE(parseSymbolFilter("   \t  ").empty());
+}
+
+TEST(SymbolBrowserFilterTests, ParseLowercasesAndSplitsOnWhitespace) {
+    const auto words = parseSymbolFilter("  Foo\tBAR  Baz ");
+    ASSERT_EQ(words.size(), 3U);
+    EXPECT_EQ(words[0], "foo");
+    EXPECT_EQ(words[1], "bar");
+    EXPECT_EQ(words[2], "baz");
+}
+
+TEST(SymbolBrowserFilterTests, EmptyWordListMatchesAnything) {
+    EXPECT_TRUE(symbolFilterMatches({}, "anything at all"));
+    EXPECT_TRUE(symbolFilterMatches({}, ""));
+}
+
+TEST(SymbolBrowserFilterTests, EveryWordMustMatch) {
+    const std::vector<wxString> words { "foo", "bar" };
+    EXPECT_TRUE(symbolFilterMatches(words, "foo and bar present"));
+    EXPECT_FALSE(symbolFilterMatches(words, "only foo present"));
+}
+
+TEST(SymbolBrowserFilterTests, WordsMatchAsSubstrings) {
+    // A single word matches anywhere in the haystack — name, kind keyword
+    // or owner-qualified prefix all live in the same lowercased string.
+    EXPECT_TRUE(symbolFilterMatches({ "ype" }, "mytype.draw function"));
+    EXPECT_TRUE(symbolFilterMatches({ "mytype" }, "mytype.draw function"));
+    EXPECT_FALSE(symbolFilterMatches({ "missing" }, "mytype.draw function"));
+}


### PR DESCRIPTION
Stack a wxSearchCtrl above the symbol tree (new SymbolBrowserPanel) and filter the tree in real time as the user types.

- Multiple whitespace-separated words: every word must match a result.
- Each word matches a result's name, its english symbol-type word (sub, function, type/udt, ...) or the localised group label.
- UDT members carry their owning type name, so filtering by a UDT shows that type with all of its members.

Also fills in the missing locale entries for the constructor, destructor, operator and property groups across all locales, plus a searchHint placeholder string for the new search box.