### PR TITLE
Auto-indent and auto-close preprocessor blocks

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -9,6 +9,7 @@
 - Added constructors, destructors, operators and properties to the symbol browser
 - Changed symbol browser to group UDT methods (subs, functions, constructors, …) under their owning type
 - Added a search box to the symbol browser to filter results live by name, symbol type or UDT
+- Added auto-indent and closer insertion for preprocessor blocks (#72)
 
 # Changes since 0.5.0-beta.3
 

--- a/src/lib/editor/AutoIndent.cpp
+++ b/src/lib/editor/AutoIndent.cpp
@@ -36,6 +36,12 @@ auto firstKeyword(const std::vector<Token>& tokens) -> KeywordKind {
         if (isLayout(t.kind) || t.kind == TokenKind::Comment || t.kind == TokenKind::CommentBlock) {
             continue;
         }
+        if (t.kind == TokenKind::Preprocessor) {
+            // A preprocessor directive (`#if`, `#macro`, `#endif`, ...) is a
+            // single token carrying its structural kind. It is not word-like,
+            // so classify it here rather than falling through to the bail-out.
+            return t.keywordKind;
+        }
         if (!isWordLike(t.kind)) {
             return KeywordKind::None;
         }
@@ -152,13 +158,19 @@ auto isCloser(const KeywordKind first) -> bool {
     return first == KeywordKind::End
         || first == KeywordKind::Loop
         || first == KeywordKind::Next
-        || first == KeywordKind::Wend;
+        || first == KeywordKind::Wend
+        || first == KeywordKind::PpEndIf
+        || first == KeywordKind::PpEndMacro;
 }
 
 auto isMid(const KeywordKind first) -> bool {
     return first == KeywordKind::Else
         || first == KeywordKind::ElseIf
-        || first == KeywordKind::Case;
+        || first == KeywordKind::Case
+        || first == KeywordKind::PpElse
+        || first == KeywordKind::PpElseIf
+        || first == KeywordKind::PpElseIfDef
+        || first == KeywordKind::PpElseIfNDef;
 }
 
 auto isOpener(const std::vector<Token>& tokens) -> bool {
@@ -188,6 +200,14 @@ auto isOpener(const std::vector<Token>& tokens) -> bool {
         return lastSignificantKeyword(tokens) == KeywordKind::Then;
     case KeywordKind::Type:
         return secondStructuralKeyword(tokens) != KeywordKind::As;
+    // Preprocessor blocks (`#if` / `#ifdef` / `#ifndef` / `#macro`) have no
+    // single-line form — they always open a block closed by `#endif` /
+    // `#endmacro`.
+    case KeywordKind::PpIf:
+    case KeywordKind::PpIfDef:
+    case KeywordKind::PpIfNDef:
+    case KeywordKind::PpMacro:
+        return true;
     default:
         return false;
     }
@@ -213,6 +233,10 @@ constexpr std::array<std::string_view, 2> kEndWith { "end", "with" };
 constexpr std::array<std::string_view, 2> kEndNS { "end", "namespace" };
 constexpr std::array<std::string_view, 2> kEndScope { "end", "scope" };
 constexpr std::array<std::string_view, 2> kEndAsm { "end", "asm" };
+// Preprocessor closers are single directive tokens — the `#` is part of the
+// keyword, lowercase; the renderer applies the KeywordPP case rule.
+constexpr std::array<std::string_view, 1> kPpEndIf { "#endif" };
+constexpr std::array<std::string_view, 1> kPpEndMacro { "#endmacro" };
 
 auto closerFor(const KeywordKind k) -> std::span<const std::string_view> {
     switch (k) {
@@ -252,6 +276,12 @@ auto closerFor(const KeywordKind k) -> std::span<const std::string_view> {
         return kEndScope;
     case KeywordKind::Asm:
         return kEndAsm;
+    case KeywordKind::PpIf:
+    case KeywordKind::PpIfDef:
+    case KeywordKind::PpIfNDef:
+        return kPpEndIf;
+    case KeywordKind::PpMacro:
+        return kPpEndMacro;
     default:
         return {};
     }

--- a/src/lib/editor/CodeTransformer.cpp
+++ b/src/lib/editor/CodeTransformer.cpp
@@ -292,13 +292,17 @@ void CodeTransformer::transformRange(Editor& editor, const int rangeStart, const
 }
 
 auto CodeTransformer::renderCloser(const std::span<const std::string_view> words) const -> wxString {
-    // Closers are Keyword1 words (`end`, `if`, `sub`, ...). Honour the
-    // per-group case rule only when the master keyword-case toggle is on;
-    // otherwise keep the lowercase form supplied by AutoIndent so the
-    // closer matches the user's "no transformation" preference.
-    const auto kw1Mode = m_keywordCases[indexOfKeywordGroup(ThemeCategory::Keywords)];
-    const auto rule = (m_transformKeywords && kw1Mode != CaseMode::None)
-                        ? kw1Mode
+    // Closers are keyword words supplied lowercase by AutoIndent — Keyword1
+    // for language closers (`end`, `if`, `sub`, ...), KeywordPP for
+    // preprocessor closers (`#endif`, `#endmacro`). Honour the matching
+    // group's case rule only when the master keyword-case toggle is on;
+    // otherwise keep the lowercase form so the closer matches the user's
+    // "no transformation" preference.
+    const bool isPreprocessor = !words.empty() && words.front().starts_with('#');
+    const auto group = isPreprocessor ? ThemeCategory::KeywordPP : ThemeCategory::Keywords;
+    const auto groupMode = m_keywordCases[indexOfKeywordGroup(group)];
+    const auto rule = (m_transformKeywords && groupMode != CaseMode::None)
+                        ? groupMode
                         : CaseMode { CaseMode::Lower };
 
     wxString out;

--- a/tests/unit/AutoIndentTests.cpp
+++ b/tests/unit/AutoIndentTests.cpp
@@ -304,3 +304,50 @@ TEST_F(AutoIndentTests, NoCloserForNonOpeners) {
     EXPECT_TRUE(closerWords("End If").empty());
     EXPECT_TRUE(closerWords("Print x").empty());
 }
+
+// ---------------------------------------------------------------------------
+// Preprocessor compound statements — `#if`/`#ifdef`/`#ifndef` -> `#endif`,
+// `#macro` -> `#endmacro`, mirroring language-level block behaviour.
+// ---------------------------------------------------------------------------
+
+TEST_F(AutoIndentTests, PreprocessorConditionalOpens) {
+    EXPECT_TRUE(opener("#if FOO"));
+    EXPECT_TRUE(opener("#ifdef FOO"));
+    EXPECT_TRUE(opener("#ifndef FOO"));
+    EXPECT_TRUE(opener("    #if FOO"));
+}
+
+TEST_F(AutoIndentTests, PreprocessorMacroOpens) {
+    EXPECT_TRUE(opener("#macro DOUBLE(x)"));
+}
+
+TEST_F(AutoIndentTests, PreprocessorClosers) {
+    EXPECT_TRUE(closer("#endif"));
+    EXPECT_TRUE(closer("#endmacro"));
+}
+
+TEST_F(AutoIndentTests, PreprocessorMidBlock) {
+    EXPECT_TRUE(mid("#else"));
+    EXPECT_TRUE(mid("#elseif BAR"));
+    EXPECT_TRUE(mid("#elseifdef BAR"));
+    EXPECT_TRUE(mid("#elseifndef BAR"));
+}
+
+TEST_F(AutoIndentTests, PreprocessorNonBlockNeutral) {
+    EXPECT_TRUE(neutral("#define FOO 1"));
+    EXPECT_TRUE(neutral("#include \"foo.bi\""));
+    EXPECT_TRUE(neutral("#undef FOO"));
+}
+
+TEST_F(AutoIndentTests, AutoClosePreprocessor) {
+    EXPECT_EQ(closerWords("#if FOO"), (std::vector<std::string_view> { "#endif" }));
+    EXPECT_EQ(closerWords("#ifdef FOO"), (std::vector<std::string_view> { "#endif" }));
+    EXPECT_EQ(closerWords("#ifndef FOO"), (std::vector<std::string_view> { "#endif" }));
+    EXPECT_EQ(closerWords("#macro M(x)"), (std::vector<std::string_view> { "#endmacro" }));
+}
+
+TEST_F(AutoIndentTests, NoCloserForPreprocessorNonOpeners) {
+    EXPECT_TRUE(closerWords("#endif").empty());
+    EXPECT_TRUE(closerWords("#else").empty());
+    EXPECT_TRUE(closerWords("#define FOO 1").empty());
+}


### PR DESCRIPTION
`#if` / `#ifdef` / `#ifndef` and `#macro` now behave like language-level compound statements: pressing Enter indents the body and inserts the matching `#endif` / `#endmacro` closer, and `#else` / `#elseif` / `#elseifdef` / `#elseifndef` dedent as mid-block keywords.

The lexer already classifies these directives; AutoIndent simply did not look at the preprocessor directive token (it is a single token, not word-like). renderCloser now picks the KeywordPP case group for `#` closers so they follow the preprocessor keyword-case rule.

Closes #72