### PR TITLE
Replace READONLY-mirror with per-category .local.ini overlays

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,3 +34,5 @@ CheckOptions:
     value: 'false'
   - key: misc-include-cleaner.UnusedIncludes
     value: 'false'
+  - key: cppcoreguidelines-pro-bounds-avoid-unchecked-container-access.ExcludeClasses
+    value: '::fbide::Value;::std::unordered_map;::std::map'

--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,7 @@
 # Changes since 0.5.0-rc.2
 
+- Changed READONLY-bundled IDE resources from one-shot full-copy mirror to per-category `.local.ini` overlays — bundle defaults now propagate to users on upgrade, and only divergent values persist in the overlay
+- Added two-dir theme enumeration under READONLY: themes in `<user-data-dir>/themes/` shadow same-named bundle themes; theme edits save there too
 - Fixed `#include` opening the same file in multiple tabs on case-insensitive filesystems (#87)
 - Added a confirm-and-close prompt when Save As targets a file already open in another tab
 - Added basic Markdown syntax highlighting for `.md` / `.markdown` files

--- a/docs/layered-config.md
+++ b/docs/layered-config.md
@@ -1,0 +1,191 @@
+# Layered Config Plan
+
+Branch: `feature/layered-config`
+
+## Problem
+
+The current `READONLY` sentinel triggers a one-shot photocopy of the bundle's IDE resources to `<UserDataDir>/ide/` via `copyMissingResources` (`src/lib/config/ConfigManager.cpp:52`). The copy only fills *missing* files, never refreshes existing ones. Consequence: any bundle update that changes a key in an already-mirrored file never reaches the user. The shipped defaults silently rot.
+
+## Approach: per-category overlay (`.local.ini`)
+
+For the four mutable INI categories — `config`, `keywords`, `shortcuts`, `layout` — introduce a `<base>.local.ini` overlay file holding only keys whose value differs from the bundle baseline. At load: parse bundle → parse overlay → deep-merge overlay over baseline. At save: diff merged tree against the retained baseline, persist only divergent leaves; empty overlay → delete file.
+
+- Overlay structure mirrors the base file 1:1. No special sections, no add/remove markers, no metadata.
+- Key-presence in overlay = override at that path, regardless of value (empty values are still overrides).
+- `locale` stays bundle-only — never copied, never overlaid. Custom locales handled by setting `locale=<path>` in `config_<plat>.local.ini`.
+- Themes get a parallel but file-granular treatment (see Theme handling below).
+
+The `READONLY` sentinel is reduced to a single routing flag: it only decides *where* writable files live (`<UserDataDir>` vs next to bundle). The mirror+copy mechanism is deleted entirely.
+
+## Storage matrix
+
+| category | bundle | overlay (default boot) | overlay location, READONLY | overlay location, portable | under `--config=PATH` |
+|---|---|---|---|---|---|
+| config | `<ideDir>/config_<plat>.ini` | yes | `<UserDataDir>/config_<plat>.local.ini` | `<ideDir>/config_<plat>.local.ini` | direct — no overlay |
+| keywords | `<ideDir>/keywords.ini` | yes | `<UserDataDir>/keywords.local.ini` | `<ideDir>/keywords.local.ini` | direct |
+| shortcuts | `<ideDir>/shortcuts_<plat>.ini` | yes | `<UserDataDir>/shortcuts_<plat>.local.ini` | `<ideDir>/shortcuts_<plat>.local.ini` | direct |
+| layout | `<ideDir>/layout.ini` | yes | `<UserDataDir>/layout.local.ini` | `<ideDir>/layout.local.ini` | direct |
+| locale | `<ideDir>/locales/<lang>.ini` | no — bundle-only | n/a | n/a | n/a |
+| themes | `<ideDir>/themes/*.ini` (+ `.fbt` legacy) | full files, no overlay | user dir `<UserDataDir>/themes/`, copy-on-modify | edit in place in bundle dir | unchanged |
+
+## `ConfigStrategy`
+
+Internal value type encapsulating per-category storage policy. Lives entirely inside the config layer; `App.cpp` does not see it.
+
+```cpp
+class ConfigStrategy final {
+public:
+    [[nodiscard]] static auto overlay(wxString basePath, wxString overlayPath) -> ConfigStrategy;
+    [[nodiscard]] static auto direct(wxString path) -> ConfigStrategy;
+
+    [[nodiscard]] auto basePath()    const -> const wxString&;
+    [[nodiscard]] auto overlayPath() const -> const wxString&;   // empty when direct
+    [[nodiscard]] auto savePath()    const -> const wxString&;   // overlay if Overlay, base if Direct
+    [[nodiscard]] auto usesOverlay() const -> bool;
+
+private:
+    enum class Mode : std::uint8_t { Overlay, Direct };
+    Mode     m_mode { Mode::Direct };
+    wxString m_basePath {};
+    wxString m_overlayPath {};
+};
+```
+
+`Entry` carries one. Built inside the `ConfigManager` ctor using existing bootstrap inputs (`appPath`, `idePath`, `configPath`) plus the sentinel result. The public `ConfigManager` constructor signature is unchanged.
+
+## Strategy selection rules
+
+Inside the `ConfigManager` ctor, after `m_appDir` / `m_ideDir` / READONLY detection:
+
+- **`--config=PATH` passed** → `Config` category gets `ConfigStrategy::direct(PATH)`. The other three mutable categories *also* get `direct(...)` resolved against the paths the explicit config names. No overlays anywhere in this mode — reproducibility for CI / repro / `fbide --config=test.ini`.
+- **Default boot** → every mutable category gets `ConfigStrategy::overlay(basePath, overlayPath)`:
+  - `basePath` — bundle file resolved against `m_ideDir`.
+  - `overlayPath` — `<UserDataDir>/<base>.local.ini` if READONLY sentinel present, else `<ideDir>/<base>.local.ini`.
+
+`reloadConfig(path)` and `setCategoryPath(cat, path)` rebuild a fresh `ConfigStrategy` for the affected category using the same rules (the ctor retains `appDir` / `ideDir` / READONLY flag for this).
+
+## Load / save behaviour
+
+### `load(category)`
+
+1. Parse `strategy.basePath()` via `wxFileConfig` → baseline `Value` tree (same as today's `importGroup`, `ConfigManager.cpp:111`).
+2. If `strategy.usesOverlay()` and the overlay file exists → parse it the same way, then deep-merge overlay leaves over baseline.
+3. Store **both** baseline and merged tree on `Entry`. Baseline is needed for save-time diff.
+4. Existing missing-file fatality rules apply only to the baseline (`Config` / `Layout` / `Locale` fatal; `Keywords` / `Shortcuts` silent-empty). Missing overlay is always fine.
+
+### `save(category)`
+
+- **`Direct` strategy** → write merged tree to `savePath()`. Existing `exportGroup` against the pre-parsed `wxFileConfig` (same read-before-write trick on `ConfigManager.cpp:478` to preserve comments / ordering).
+- **`Overlay` strategy** → diff merged tree against retained baseline. Collect every leaf path whose effective value differs (presence-with-different-value *or* presence-where-baseline-has-no-key). Write that subset to `overlayPath()`. If the diff is empty, delete the overlay file (or skip writing if it doesn't exist). Read the existing overlay file first to preserve comments / ordering for hand-edited overlays.
+
+Keywords use the same logic: any leaf present in the overlay overrides the same leaf in baseline, regardless of value. No special add/remove sections.
+
+### `reloadIfKnown(path)`
+
+Match `path` against `strategy.basePath()` *or* `strategy.overlayPath()` for each category — either triggers a reload of that category (and the cascade if it's `Config`). Theme path matching unchanged.
+
+## Migration of legacy mirrored files
+
+Existing READONLY-bundled users have full-copy `<base>.ini` files in `<UserDataDir>` from the old mirror. One-shot per category, performed in the ctor when READONLY sentinel is present:
+
+For each mutable category:
+- `legacyPath = <UserDataDir>/<base>.ini`.
+- `overlayPath = <UserDataDir>/<base>.local.ini`.
+- If `legacyPath` exists and `overlayPath` does **not** exist:
+  1. Load bundle baseline.
+  2. Parse `legacyPath` independently.
+  3. Diff legacy against baseline → trimmed `Value` tree.
+  4. Write the trimmed tree to `overlayPath` (skip the write if empty).
+  5. Delete `legacyPath`.
+  6. Log `"migrated <base>.ini → <base>.local.ini (N keys retained)"`.
+- If `overlayPath` already exists, the user has run a new build before — no migration; legacy file left untouched (don't double-trample).
+
+Old per-user theme copies under `<UserDataDir>/ide/themes/` are picked up by the new two-dir theme enumeration with no intervention.
+
+## Theme handling
+
+Two writable mechanisms depending on READONLY:
+
+- **READONLY present** — bundle themes immutable in `<ideDir>/themes/`. User themes live in `<UserDataDir>/themes/`. `getAllThemes()` enumerates both dirs, user dir wins on basename collision. Editing a bundle-owned theme triggers copy-on-modify: duplicate file to user themes dir, repoint `config["theme"]`, then open editor. Default duplicate name: `<original>-copy.ini`.
+- **READONLY absent** — bundle themes dir is itself writable. Edits go in place. New themes saved into the same `<ideDir>/themes/` dir. No two-dir enumeration needed (or equivalently: bundle dir == user dir).
+
+`absolute()` for `config["theme"]` resolution: prefer `<UserDataDir>/themes/<rel>` first when READONLY, then existing fallback chain (`ideDir`, `appDir`, `cwd`). Stored value remains a relative path like `themes/dark.ini`.
+
+`Theme::save()` always targets the writable themes dir for the current mode. `.fbt` legacy extension stays readable via the existing `enumerate` glob (`ConfigManager.cpp:179`).
+
+## Files touched
+
+- `src/lib/config/ConfigStrategy.hpp` (new) — value type definition + factories.
+- `src/lib/config/ConfigStrategy.cpp` (new, tiny) — out-of-line factories if needed.
+- `src/lib/config/ConfigManager.hpp` — `Entry` gains `ConfigStrategy strategy` and baseline `Value`; small accessor additions for theme dirs.
+- `src/lib/config/ConfigManager.cpp`:
+  - Bootstrap rewritten to build `ConfigStrategy` per category.
+  - `load()` / `save()` rewritten around strategy.
+  - New helpers: `mergeOverlay(baseline, overlay)`, `diffAgainstBaseline(merged, baseline)`, `migrateLegacyMirror(category)`.
+  - `copyMissingResources` deleted; `hasReadOnlySentinel` kept (reduced role).
+  - Theme `absolute()` resolution gets user-themes-dir preference.
+- Theme call sites — wire copy-on-modify trigger (locate during stage 8).
+- `tests/unit/ConfigManagerTests.cpp` — new coverage (see Test surface).
+
+`App.cpp`, `Context.{hpp,cpp}`, and every existing consumer of `ConfigManager`'s public API (`config()` / `save()` / `reloadIfKnown()` / etc.) are untouched.
+
+## Test surface
+
+`tests/unit/ConfigManagerTests.cpp` currently has no READONLY / mirror / migration coverage. New cases:
+
+- **Overlay merge** — baseline + overlay → merged tree; overlay leaf replaces baseline leaf at same path, regardless of value (including empty string).
+- **Aggressive prune on save** — saving a value that matches baseline → key absent from overlay; saving a divergent value → key present; saving with no diffs → overlay file deleted.
+- **Strategy selection** — default boot vs `--config=PATH` build the right strategy per category; READONLY vs portable route overlay path to the correct dir.
+- **Migration** — legacy `<base>.ini` present, no `.local.ini` → migrated, trimmed `.local.ini` written, legacy deleted; legacy present with existing `.local.ini` → no-op, legacy untouched.
+- **Reload** — `reloadIfKnown(overlayPath)` triggers reload; `reloadIfKnown(basePath)` triggers reload; `Config` cascade still fires.
+- **Hand-edited overlay preserved** — round-trip a manually written overlay with comments through `load` → `save` without losing them.
+
+Themes: extend existing tests with a copy-on-modify case once stage 8 lands.
+
+## Implementation order
+
+Each stage should pass `verify` before the next begins.
+
+1. **Introduce `ConfigStrategy`** (header + small `.cpp`). No callers yet. Trivial unit test that factories produce expected accessors.
+2. **Add baseline `Value` to `Entry`.** Refactor `load()` to populate it. Still no overlay merging — behaviour unchanged.
+3. **Overlay merge in `load()`** behind a single `usesOverlay()` check. Overlay paths still empty at this point → no behavioural change in production code; new merge helper unit-tested in isolation.
+4. **Switch ctor to build `ConfigStrategy`** per category from the new rules. Overlay paths now populated. Default boot + `--config=PATH` both wired. Overlay files now load if present but no save logic yet → safe to ship behind a single commit.
+5. **Rewrite `save()`** around strategy — diff + prune for overlay; direct write for direct. After this commit overlays are produced and consumed end-to-end.
+6. **Legacy-mirror migration step** in ctor (READONLY only). Test thoroughly — touches user-dir files destructively.
+7. **Delete `copyMissingResources`** and the READONLY mirroring branch. Reduce `hasReadOnlySentinel` to the routing role.
+8. **Theme copy-on-modify** — locate the theme-edit entry point, add the duplicate-then-repoint flow, add `<UserDataDir>/themes/` to enumeration + `absolute()` precedence.
+9. **Test additions** alongside each stage.
+
+## Deferred to implementation time
+
+- Exact location of the theme copy-on-modify trigger (which class / menu action) — quick grep when stage 8 lands.
+- Whether existing `Theme::save()` supports targeting an arbitrary path or needs a small addition.
+- Naming of `tests/data/` fixtures for migration / overlay scenarios.
+
+## Out of scope
+
+- UI for browsing / managing overlays (no "Default vs User Settings" diff view like VS Code).
+- Versioning / migration of overlay schema across breaking config-key renames (handled ad-hoc if it comes up).
+- Auto-import of dropped `.ini` theme files (drag-and-drop import) — possible future ergonomics.
+
+## Implementation tasks
+
+TDD where the unit is a pure function over data (helpers); refactor / integration-style where TDD wouldn't earn its keep.
+
+1. **Survey ConfigManagerTests** — inventory existing coverage; identify test seams (likely need an optional `userDataDirOverride` ctor param). Research only.
+2. **TDD: `ConfigStrategy` value type** — tests for `overlay()` / `direct()` factories and accessors → implement.
+3. **Refactor `Entry` to carry `ConfigStrategy` + baseline `Value`** — no behaviour change; existing tests stay green.
+4. **TDD: `mergeOverlay(baseline, overlay)` helper** — pure function over `Value` trees: leaf override regardless of value, recursive group merge, empty overlay no-op.
+5. **TDD: `selectStrategy()` pure helper** — per-category strategy from `(category, ideDir, userDataDir, readOnly, explicitConfigPath)`.
+6. **Add `userDataDirOverride` test seam** — single optional ctor param, used only by tests.
+7. **Wire `mergeOverlay` into `load()`** — end-to-end overlay loading; integration tests for READONLY vs portable routing.
+8. **TDD: `diffAgainstBaseline(merged, baseline)` helper** — returns subset of merged whose leaves differ; deletion semantics deferred to user-edited overlay.
+9. **Rewrite `save()` around `ConfigStrategy`** — diff+prune for Overlay, direct write for Direct; preserve hand-edited overlay comments via read-before-write.
+10. **TDD: `migrateLegacyMirror` helper** — diff legacy against bundle, write trimmed overlay, delete legacy; no-op if overlay already exists.
+11. **Delete `copyMissingResources`** + reduce `hasReadOnlySentinel` to routing flag.
+12. **Update `reloadIfKnown`** to match base OR overlay path per category; preserve Config cascade.
+13. **Clarify + implement `setCategoryPath` / `reloadConfig`** under layered model (former = new bundle + derived overlay; latter = Direct, matching `--config=PATH` semantics at runtime).
+14. **TDD: two-dir theme enumeration + `absolute()` precedence** — user themes win on collision; portable mode = single dir.
+15. **Locate theme copy-on-modify trigger** and wire duplicate-then-repoint flow; TDD the pure helpers (`isBundleTheme`, duplicate-path resolution); manual smoke for the UI.
+16. **Manual smoke verification on .app bundle** — fresh launch, mutate, restart, simulate bundle update, simulate legacy migration.
+17. **Update `change-log.md`** with the user-visible behaviour change.

--- a/docs/layered-config.md
+++ b/docs/layered-config.md
@@ -86,21 +86,7 @@ Match `path` against `strategy.basePath()` *or* `strategy.overlayPath()` for eac
 
 ## Migration of legacy mirrored files
 
-Existing READONLY-bundled users have full-copy `<base>.ini` files in `<UserDataDir>` from the old mirror. One-shot per category, performed in the ctor when READONLY sentinel is present:
-
-For each mutable category:
-- `legacyPath = <UserDataDir>/<base>.ini`.
-- `overlayPath = <UserDataDir>/<base>.local.ini`.
-- If `legacyPath` exists and `overlayPath` does **not** exist:
-  1. Load bundle baseline.
-  2. Parse `legacyPath` independently.
-  3. Diff legacy against baseline → trimmed `Value` tree.
-  4. Write the trimmed tree to `overlayPath` (skip the write if empty).
-  5. Delete `legacyPath`.
-  6. Log `"migrated <base>.ini → <base>.local.ini (N keys retained)"`.
-- If `overlayPath` already exists, the user has run a new build before — no migration; legacy file left untouched (don't double-trample).
-
-Old per-user theme copies under `<UserDataDir>/ide/themes/` are picked up by the new two-dir theme enumeration with no intervention.
+**Skipped.** FBIde has only shipped in beta / rc to date, so we don't carry forward the legacy full-copy `<base>.ini` files that the old mirror produced in `<UserDataDir>`. Existing pre-release users with a stale mirror will see fresh empty overlays on first launch with the new code; if they want their prior customisations they re-apply them by hand. Old per-user theme copies under `<UserDataDir>/ide/themes/` are still picked up by the new two-dir theme enumeration — they just won't migrate to a different layout.
 
 ## Theme handling
 
@@ -181,7 +167,7 @@ TDD where the unit is a pure function over data (helpers); refactor / integratio
 7. **Wire `mergeOverlay` into `load()`** — end-to-end overlay loading; integration tests for READONLY vs portable routing.
 8. **TDD: `diffAgainstBaseline(merged, baseline)` helper** — returns subset of merged whose leaves differ; deletion semantics deferred to user-edited overlay.
 9. **Rewrite `save()` around `ConfigStrategy`** — diff+prune for Overlay, direct write for Direct; preserve hand-edited overlay comments via read-before-write.
-10. **TDD: `migrateLegacyMirror` helper** — diff legacy against bundle, write trimmed overlay, delete legacy; no-op if overlay already exists.
+10. ~~**TDD: `migrateLegacyMirror` helper**~~ — skipped: pre-release versions only, no migration story owed to users.
 11. **Delete `copyMissingResources`** + reduce `hasReadOnlySentinel` to routing flag.
 12. **Update `reloadIfKnown`** to match base OR overlay path per category; preserve Config cascade.
 13. **Clarify + implement `setCategoryPath` / `reloadConfig`** under layered model (former = new bundle + derived overlay; latter = Direct, matching `--config=PATH` semantics at runtime).

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(fbide_lib
     compiler/CompilerManager.cpp
     compiler/RunCommand.cpp
     config/ConfigManager.cpp
+    config/ConfigStrategy.cpp
     config/FileHistory.cpp
     config/Theme.cpp
     config/Value.cpp
@@ -88,6 +89,7 @@ target_sources(fbide_lib
     compiler/QuoteUtils.hpp
     compiler/RunCommand.hpp
     config/ConfigManager.hpp
+    config/ConfigStrategy.hpp
     config/FileHistory.hpp
     config/Theme.hpp
     config/ThemeCategory.hpp

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -572,6 +572,9 @@ void ConfigManager::save(const Category category) {
             }
             return;
         }
+        // Ensure parent dir exists — under READONLY this is
+        // `<UserDataDir>` which may not exist on first launch.
+        wxFileName::Mkdir(wxFileName(overlayPath).GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         wxFileConfig overlayCfg;
         wxFFileOutputStream outStream(overlayPath);
         if (!outStream.IsOk()) {

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -142,7 +142,50 @@ auto ConfigManager::getAllLanguages() const -> std::vector<wxString> {
 }
 
 auto ConfigManager::getAllThemes() const -> std::vector<wxString> {
-    return enumerate(m_ideDir / "themes", { "*.ini", "*.fbt" });
+    auto bundle = enumerate(m_ideDir / "themes", { "*.ini", "*.fbt" });
+    if (!m_readOnlyIde) {
+        return bundle;
+    }
+    auto user = enumerate(m_userDataDir / "themes", { "*.ini", "*.fbt" });
+
+    // Two-dir merge — user entries shadow bundle entries on basename
+    // collision. `std::unordered_map` because the pch ships unordered
+    // but not ordered map; sort by basename in a separate pass.
+    std::unordered_map<wxString, wxString> byName;
+    for (auto& path : bundle) {
+        byName[wxFileName(path).GetFullName()] = std::move(path);
+    }
+    for (auto& path : user) {
+        byName[wxFileName(path).GetFullName()] = std::move(path);
+    }
+    std::vector<wxString> merged;
+    merged.reserve(byName.size());
+    for (auto& value : std::views::values(byName)) {
+        merged.push_back(std::move(value));
+    }
+    std::ranges::sort(merged, [](const wxString& a, const wxString& b) {
+        return wxFileName(a).GetFullName() < wxFileName(b).GetFullName();
+    });
+    return merged;
+}
+
+auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
+    if (relPath.empty()) {
+        return relPath;
+    }
+    if (wxFileName fn { relPath }; fn.IsAbsolute()) {
+        return fn.GetAbsolutePath();
+    }
+    // READONLY: user override at `<UserDataDir>/<relPath>` wins. Probed
+    // before the generic `absolute()` walk so a same-named bundle theme
+    // never shadows the user's edit.
+    if (m_readOnlyIde) {
+        const wxString candidate = m_userDataDir + wxFILE_SEP_PATH + relPath;
+        if (wxFileExists(candidate)) {
+            return wxFileName(candidate).GetAbsolutePath();
+        }
+    }
+    return absolute(relPath);
 }
 
 auto ConfigManager::getPlatformConfigFileName() -> wxString {
@@ -294,7 +337,7 @@ ConfigManager::ConfigManager(
     // configured theme file is missing or absent, fall back to a built-in
     // minimal theme so the editor still launches with a usable scheme.
     if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
-        const auto themeAbs = absolute(themeRel);
+        const auto themeAbs = themePath(themeRel);
         if (wxFileExists(themeAbs)) {
             m_theme.load(themeAbs);
             wxLogMessage("Loaded theme from %s", themeAbs);
@@ -339,7 +382,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
     }
 
     if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
-        const auto themeAbs = absolute(themeRel);
+        const auto themeAbs = themePath(themeRel);
         if (wxFileExists(themeAbs)) {
             m_theme.load(themeAbs);
         } else {
@@ -557,7 +600,7 @@ auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
                     load(m_categories[sub].category);
                 }
                 if (const auto themeRel = config().get_or("theme", ""); not themeRel.empty()) {
-                    m_theme.load(absolute(themeRel));
+                    m_theme.load(themePath(themeRel));
                 }
             }
             return true;

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -330,6 +330,14 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
     entry.strategy = buildStrategy(Category::Config, absolute(configPath));
     load(Category::Config);
 
+    // Cascade — sub-categories were loaded under the prior mode (likely
+    // Overlay). After flipping to explicit they need fresh strategies
+    // so subsequent saves honour the Direct rule. load() rebuilds the
+    // strategy via buildStrategy() using the new m_explicitConfig.
+    for (const auto cat : { Category::Locale, Category::Shortcuts, Category::Keywords, Category::Layout }) {
+        load(cat);
+    }
+
     if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
         const auto themeAbs = absolute(themeRel);
         if (wxFileExists(themeAbs)) {

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -173,7 +173,9 @@ auto ConfigManager::getAllThemes() const -> std::vector<wxString> {
 }
 
 auto ConfigManager::themesWriteDir() const -> wxString {
-    return (m_readOnlyIde ? m_userDataDir : m_ideDir) / "themes";
+    const auto dir = (m_readOnlyIde ? m_userDataDir : m_ideDir) / "themes";
+    wxFileName::Mkdir(dir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    return dir;
 }
 
 auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
@@ -187,7 +189,7 @@ auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
     // before the generic `absolute()` walk so a same-named bundle theme
     // never shadows the user's edit.
     if (m_readOnlyIde) {
-        const wxString candidate = m_userDataDir + wxFILE_SEP_PATH + relPath;
+        const wxString candidate = m_userDataDir / relPath;
         if (wxFileExists(candidate)) {
             return wxFileName(candidate).GetAbsolutePath();
         }
@@ -730,21 +732,20 @@ auto makeRelative(const wxString& path, const wxString& to) -> std::optional<wxS
 
 auto ConfigManager::relative(const wxString& path) const -> wxString {
     const auto abs = absolute(path);
-    if (const auto ide = makeRelative(m_ideDir, abs)) {
-        return *ide;
-    }
-    // User data dir is the writable equivalent of the bundle's ide/ —
-    // a path like `<UserDataDir>/themes/dark.ini` belongs to the same
-    // logical layout and must stringify as the same relative form so
-    // `themePath()` round-trips correctly on the next load. Without
-    // this, theme saves under READONLY leaked absolute paths into
-    // `config["theme"]`. `m_userDataDir` is always populated (ctor
-    // falls back to `wxStandardPaths` when no override) so no guard.
-    if (const auto userData = makeRelative(m_userDataDir, abs)) {
-        return *userData;
-    }
-    if (const auto app = makeRelative(m_appDir, abs)) {
-        return *app;
+    // Candidate base dirs, in priority order:
+    // - m_ideDir       — bundle resources.
+    // - m_userDataDir  — writable equivalent of ide/ (always populated;
+    //                    ctor falls back to wxStandardPaths when no
+    //                    override). A path like `<userDataDir>/themes/
+    //                    dark.ini` must stringify the same as the
+    //                    bundle equivalent so themePath() round-trips
+    //                    correctly on the next load.
+    // - m_appDir       — binary directory; fallback for portable
+    //                    side-by-side layouts.
+    for (const auto* base : { &m_ideDir, &m_userDataDir, &m_appDir }) {
+        if (const auto rel = makeRelative(*base, abs)) {
+            return *rel;
+        }
     }
     return path;
 }

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -35,49 +35,15 @@ void dismissSplash() {
 namespace {
 /// Sentinel filename. When present in the IDE resources directory, that
 /// directory is treated as read-only (e.g. inside a macOS .app bundle,
-/// AppImage, or signed Windows install) and the resources are mirrored
-/// to a writable per-user copy on first launch.
+/// AppImage, or signed Windows install) and writable artefacts —
+/// per-category `.local.ini` overlays and theme copies — are routed to
+/// `wxStandardPaths::GetUserDataDir()` instead of next to the bundle.
 constexpr auto kReadOnlySentinel = "READONLY";
 
 /// True when the IDE resources directory carries the read-only sentinel.
 auto hasReadOnlySentinel(const wxString& dir) -> bool {
     wxFileName marker(dir, kReadOnlySentinel);
     return marker.FileExists();
-}
-
-/// Recursively copy every file under `src` to `dst`, skipping any file
-/// that already exists at the destination. Returns the number of files
-/// copied. The sentinel itself is never propagated. Missing directories
-/// at the destination are created on demand.
-auto copyMissingResources(const wxString& src, const wxString& dst) -> std::size_t {
-    std::size_t copied = 0;
-    if (!wxFileName::Mkdir(dst, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL)) {
-        wxLogWarning("Failed to create user resources directory '%s'", dst);
-        return 0;
-    }
-
-    wxDir dir(src);
-    if (!dir.IsOpened()) {
-        return 0;
-    }
-
-    wxString name;
-    bool more = dir.GetFirst(&name, wxEmptyString, wxDIR_FILES | wxDIR_DIRS);
-    while (more) {
-        const wxString srcPath = src + wxFILE_SEP_PATH + name;
-        const wxString dstPath = dst + wxFILE_SEP_PATH + name;
-        if (wxDirExists(srcPath)) {
-            copied += copyMissingResources(srcPath, dstPath);
-        } else if (name != kReadOnlySentinel && !wxFileExists(dstPath)) {
-            if (wxCopyFile(srcPath, dstPath, /*overwrite=*/false)) {
-                ++copied;
-            } else {
-                wxLogWarning("Failed to copy '%s' to '%s'", srcPath, dstPath);
-            }
-        }
-        more = dir.GetNext(&name);
-    }
-    return copied;
 }
 } // namespace
 
@@ -298,31 +264,24 @@ ConfigManager::ConfigManager(
         return;
     }
 
-    // Read-only IDE directory sentinel. When present and the user has
-    // not asked for an explicit override, mirror the resources to a
-    // writable per-user copy under wxStandardPaths::GetUserDataDir() and
-    // load/save from there. Lets bundles, AppImages, and signed
-    // installers ship truly immutable resource trees while still letting
-    // FBIde edit themes, layouts, etc. CLI overrides bypass the mirror
-    // (the user knows where they pointed FBIde) — warn so the bypass
-    // isn't silent.
-    const bool cliOverride = !idePath.empty() || !configPath.empty();
-    const bool readOnlyIde = hasReadOnlySentinel(m_ideDir);
-    if (cliOverride && readOnlyIde) {
-        wxLogWarning(
-            "READONLY sentinel found in '%s' but ignored — --ide / --config override is in effect",
-            m_ideDir
-        );
-    } else if (readOnlyIde) {
-        const wxString userIdeDir = m_userDataDir + wxFILE_SEP_PATH + "ide";
-        wxLogMessage("READONLY ide directory '%s' detected; mirroring to '%s'", m_ideDir, userIdeDir);
-        const auto copied = copyMissingResources(m_ideDir, userIdeDir);
-        wxLogMessage("Copied %zu missing resource file(s) into '%s'", copied, userIdeDir);
-        m_ideDir = userIdeDir;
+    // READONLY sentinel + explicit-config flag drive the strategy rules:
+    // - sentinel present → writable artefacts (`.local.ini` overlays,
+    //   theme copies) route to `m_userDataDir` rather than next to the
+    //   bundle. The sentinel describes the dir, not the boot mode, so
+    //   `--ide=PATH` is respected and the dir's own sentinel decides.
+    // - `--config=PATH` → all four mutable categories run `Direct` (no
+    //   overlay) so CI / repro runs aren't influenced by stray overlays.
+    m_explicitConfig = !configPath.empty();
+    m_readOnlyIde = hasReadOnlySentinel(m_ideDir);
+    if (m_readOnlyIde) {
+        wxLogMessage("READONLY sentinel detected in '%s' — overlays route to '%s'", m_ideDir, m_userDataDir);
     }
 
     auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
-    entry.strategy = ConfigStrategy::direct(absolute(configPath.empty() ? getPlatformConfigFileName() : configPath));
+    entry.strategy = buildStrategy(
+        Category::Config,
+        absolute(configPath.empty() ? getPlatformConfigFileName() : configPath)
+    );
     wxLogMessage("ide directory: %s", m_ideDir);
     load(Category::Config);
 
@@ -362,8 +321,13 @@ void ConfigManager::setCategoryPath(const Category category, const wxString& pat
 }
 
 void ConfigManager::reloadConfig(const wxString& configPath) {
+    // Runtime equivalent of `--config=PATH` — flip to explicit mode so
+    // subsequent strategy rebuilds (sub-categories, reloadIfKnown) stay
+    // `Direct`. Sub-categories already loaded under prior mode are
+    // unaffected here; full sub-category rebind is task #13 territory.
+    m_explicitConfig = true;
     auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
-    entry.strategy = ConfigStrategy::direct(absolute(configPath));
+    entry.strategy = buildStrategy(Category::Config, absolute(configPath));
     load(Category::Config);
 
     if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
@@ -380,6 +344,19 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
 }
 
 // ---------------------------------------------------------------------------
+// Strategy
+// ---------------------------------------------------------------------------
+
+auto ConfigManager::buildStrategy(const Category category, wxString basePath) const -> ConfigStrategy {
+    // Locale is the only bundle-only mutable slot (custom locales come
+    // from a user-set `locale=<path>` in the config overlay, not from an
+    // overlay of the locale file itself). Everything else is overlay-
+    // capable; the explicit-config flag still forces `Direct`.
+    const bool overlayCapable = category != Category::Locale;
+    return ConfigStrategy::select(basePath, m_userDataDir, m_readOnlyIde, overlayCapable, m_explicitConfig);
+}
+
+// ---------------------------------------------------------------------------
 // Load / save
 // ---------------------------------------------------------------------------
 
@@ -388,6 +365,10 @@ void ConfigManager::load(const Category category) {
     wxString file;
 
     if (category == Category::Config) {
+        // Strategy already built by ctor / reloadConfig before they
+        // called us — config is the bootstrap, its path is known up
+        // front. Sub-categories below get strategy built right after
+        // path resolution.
         file = entry.strategy.basePath();
     } else {
         const auto key = getCategoryName(category);
@@ -398,6 +379,7 @@ void ConfigManager::load(const Category category) {
             return;
         }
         file = absolute(*relPath);
+        entry.strategy = buildStrategy(category, file);
     }
 
     if (!wxFileExists(file)) {
@@ -445,7 +427,6 @@ void ConfigManager::load(const Category category) {
         case Category::Keywords:
         case Category::Shortcuts:
             entry.category = category;
-            entry.strategy = ConfigStrategy::direct(file);
             entry.baseline = Value {};
             entry.root = Value {};
             return;
@@ -461,10 +442,10 @@ void ConfigManager::load(const Category category) {
 
     wxFileConfig cfg(stream, wxConvUTF8);
 
-    // Parse twice so baseline and root are independent Value trees. Value
-    // is move-only by design (`Value.hpp:48-49`), and overlay-merge in
-    // stage 4 will need the baseline preserved across the merge into root.
-    // For now baseline == root since no overlay is layered in yet.
+    // Parse twice — baseline is the pristine bundle tree (needed at save
+    // time to diff against). Root starts as a second independent parse
+    // because Value is move-only by design (`Value.hpp:48-49`); the
+    // overlay merge below mutates root without touching baseline.
     Value baseline;
     cfg.SetPath("/");
     importGroup(cfg, baseline);
@@ -473,8 +454,27 @@ void ConfigManager::load(const Category category) {
     cfg.SetPath("/");
     importGroup(cfg, root);
 
+    // Overlay merge — only when the strategy provides an overlay path
+    // and that file actually exists. Missing overlay is fine; it just
+    // means the user has no divergences from bundle yet.
+    if (entry.strategy.usesOverlay() && wxFileExists(entry.strategy.overlayPath())) {
+        wxFFileInputStream overlayStream(entry.strategy.overlayPath());
+        if (overlayStream.IsOk()) {
+            wxFileConfig overlayCfg(overlayStream, wxConvUTF8);
+            Value overlay;
+            overlayCfg.SetPath("/");
+            importGroup(overlayCfg, overlay);
+            root.mergeFrom(overlay);
+            wxLogMessage(
+                "Merged overlay %s into %s",
+                entry.strategy.overlayPath(), getCategoryName(category).data()
+            );
+        } else {
+            wxLogWarning("Overlay '%s' exists but could not be read", entry.strategy.overlayPath());
+        }
+    }
+
     entry.category = category;
-    entry.strategy = ConfigStrategy::direct(file);
     entry.baseline = std::move(baseline);
     entry.root = std::move(root);
     wxLogMessage("Loaded %s from %s", getCategoryName(category).data(), file);
@@ -487,10 +487,38 @@ void ConfigManager::save(const Category category) {
         return;
     }
 
-    // Open the read stream before the write stream: wxFileConfig parses
-    // existingStream in its constructor (preserves comments + ordering),
-    // then we truncate the file for writing. Reversing the order would
-    // zero the file before parsing completed.
+    if (entry.strategy.usesOverlay()) {
+        // Aggressive prune: persist only leaves that diverge from the
+        // bundle baseline. Empty diff → no overlay file at all (delete
+        // if one existed). Overlay file is machine-managed; we write
+        // fresh from the diff rather than merging into existing keys so
+        // stale entries from prior saves don't accumulate.
+        const auto& overlayPath = entry.strategy.overlayPath();
+        const auto diff = entry.root.diffAgainst(entry.baseline);
+        if (!diff) {
+            if (wxFileExists(overlayPath)) {
+                wxRemoveFile(overlayPath);
+                wxLogMessage("Pruned empty overlay '%s'", overlayPath);
+            }
+            return;
+        }
+        wxFileConfig overlayCfg;
+        wxFFileOutputStream outStream(overlayPath);
+        if (!outStream.IsOk()) {
+            wxLogError("Failed to open '%s' for writing", overlayPath);
+            return;
+        }
+        exportGroup(diff, "", overlayCfg);
+        overlayCfg.Save(outStream, wxConvUTF8);
+        wxLogMessage("Saved overlay '%s'", overlayPath);
+        return;
+    }
+
+    // Direct mode (`--config=PATH` or locale). Open the read stream
+    // before the write stream: `wxFileConfig` parses existingStream in
+    // its constructor (preserves comments + ordering), then we truncate
+    // the file for writing. Reversing the order would zero the file
+    // before parsing completed.
     const auto& savePath = entry.strategy.savePath();
     wxFileInputStream existingStream(savePath);
     wxFileConfig cfg(existingStream, wxConvUTF8);
@@ -507,7 +535,13 @@ void ConfigManager::save(const Category category) {
 auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
     for (std::size_t index = 0; index < CAT_COUNT; index++) {
         const auto& entry = m_categories[index];
-        if (samePath(path, entry.strategy.basePath())) {
+        // Trigger reload when the user touches either side of the
+        // layered pair — the bundle base (rare; usually requires elevated
+        // perms inside a bundle) or the writable overlay.
+        const bool baseMatch = samePath(path, entry.strategy.basePath());
+        const bool overlayMatch = entry.strategy.usesOverlay()
+                               && samePath(path, entry.strategy.overlayPath());
+        if (baseMatch || overlayMatch) {
             load(entry.category);
             // if this was config, then reload all other files as well.
             if (entry.category == Category::Config) {

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -228,8 +228,14 @@ auto ConfigManager::getDefaultTerminalLauncher() -> wxString {
 // Init
 // ---------------------------------------------------------------------------
 
-ConfigManager::ConfigManager(const wxString& appPath, const wxString& idePath, const wxString& configPath)
-: m_appDir(appPath) {
+ConfigManager::ConfigManager(
+    const wxString& appPath,
+    const wxString& idePath,
+    const wxString& configPath,
+    const wxString& userDataDirOverride
+)
+: m_appDir(appPath)
+, m_userDataDir(userDataDirOverride.empty() ? wxStandardPaths::Get().GetUserDataDir() : userDataDirOverride) {
     if (not wxDirExists(appPath)) {
         wxLogError("app directory '%s' does not exist", appPath);
         return;
@@ -308,7 +314,7 @@ ConfigManager::ConfigManager(const wxString& appPath, const wxString& idePath, c
             m_ideDir
         );
     } else if (readOnlyIde) {
-        const wxString userIdeDir = wxStandardPaths::Get().GetUserDataDir() + wxFILE_SEP_PATH + "ide";
+        const wxString userIdeDir = m_userDataDir + wxFILE_SEP_PATH + "ide";
         wxLogMessage("READONLY ide directory '%s' detected; mirroring to '%s'", m_ideDir, userIdeDir);
         const auto copied = copyMissingResources(m_ideDir, userIdeDir);
         wxLogMessage("Copied %zu missing resource file(s) into '%s'", copied, userIdeDir);
@@ -316,7 +322,7 @@ ConfigManager::ConfigManager(const wxString& appPath, const wxString& idePath, c
     }
 
     auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
-    entry.path = absolute(configPath.empty() ? getPlatformConfigFileName() : configPath);
+    entry.strategy = ConfigStrategy::direct(absolute(configPath.empty() ? getPlatformConfigFileName() : configPath));
     wxLogMessage("ide directory: %s", m_ideDir);
     load(Category::Config);
 
@@ -338,7 +344,7 @@ ConfigManager::ConfigManager(const wxString& appPath, const wxString& idePath, c
             m_theme.loadDefaults();
         }
     } else {
-        wxLogWarning("No 'theme' entry found in config '%s' — using built-in default", entry.path);
+        wxLogWarning("No 'theme' entry found in config '%s' — using built-in default", entry.strategy.basePath());
         m_theme.loadDefaults();
     }
 }
@@ -357,7 +363,7 @@ void ConfigManager::setCategoryPath(const Category category, const wxString& pat
 
 void ConfigManager::reloadConfig(const wxString& configPath) {
     auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
-    entry.path = absolute(configPath);
+    entry.strategy = ConfigStrategy::direct(absolute(configPath));
     load(Category::Config);
 
     if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
@@ -382,7 +388,7 @@ void ConfigManager::load(const Category category) {
     wxString file;
 
     if (category == Category::Config) {
-        file = entry.path;
+        file = entry.strategy.basePath();
     } else {
         const auto key = getCategoryName(category);
         const auto& ref = config().at({ key.data(), key.size() });
@@ -439,7 +445,8 @@ void ConfigManager::load(const Category category) {
         case Category::Keywords:
         case Category::Shortcuts:
             entry.category = category;
-            entry.path = file;
+            entry.strategy = ConfigStrategy::direct(file);
+            entry.baseline = Value {};
             entry.root = Value {};
             return;
         }
@@ -453,13 +460,22 @@ void ConfigManager::load(const Category category) {
     }
 
     wxFileConfig cfg(stream, wxConvUTF8);
+
+    // Parse twice so baseline and root are independent Value trees. Value
+    // is move-only by design (`Value.hpp:48-49`), and overlay-merge in
+    // stage 4 will need the baseline preserved across the merge into root.
+    // For now baseline == root since no overlay is layered in yet.
+    Value baseline;
     cfg.SetPath("/");
+    importGroup(cfg, baseline);
 
     Value root;
+    cfg.SetPath("/");
     importGroup(cfg, root);
 
     entry.category = category;
-    entry.path = file;
+    entry.strategy = ConfigStrategy::direct(file);
+    entry.baseline = std::move(baseline);
     entry.root = std::move(root);
     wxLogMessage("Loaded %s from %s", getCategoryName(category).data(), file);
 }
@@ -475,11 +491,12 @@ void ConfigManager::save(const Category category) {
     // existingStream in its constructor (preserves comments + ordering),
     // then we truncate the file for writing. Reversing the order would
     // zero the file before parsing completed.
-    wxFileInputStream existingStream(entry.path);
+    const auto& savePath = entry.strategy.savePath();
+    wxFileInputStream existingStream(savePath);
     wxFileConfig cfg(existingStream, wxConvUTF8);
-    wxFFileOutputStream outStream(entry.path);
+    wxFFileOutputStream outStream(savePath);
     if (!outStream.IsOk()) {
-        wxLogError("Failed to open '%s' for writing", entry.path);
+        wxLogError("Failed to open '%s' for writing", savePath);
         return;
     }
 
@@ -490,7 +507,7 @@ void ConfigManager::save(const Category category) {
 auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
     for (std::size_t index = 0; index < CAT_COUNT; index++) {
         const auto& entry = m_categories[index];
-        if (samePath(path, entry.path)) {
+        if (samePath(path, entry.strategy.basePath())) {
             load(entry.category);
             // if this was config, then reload all other files as well.
             if (entry.category == Category::Config) {

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -540,7 +540,7 @@ void ConfigManager::load(const Category category) {
     wxLogMessage("Loaded %s from %s", catName, file);
 }
 
-void ConfigManager::save(const Category category) {
+void ConfigManager::save(const Category category) const {
     // Locale is bundle-only. The IDE never writes its translation strings
     // back; any caller asking for `save(Locale)` is a bug — flag loudly
     // rather than silently truncating the bundle locale file under

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -6,8 +6,34 @@
 //
 #include "ConfigManager.hpp"
 using namespace fbide;
+namespace fs = std::filesystem;
 
 namespace {
+// ---------------------------------------------------------------------------
+// wxString <-> std::filesystem::path conversion
+//
+// Everything inside this TU works in `fs::path`. Conversions to/from
+// `wxString` happen only at the public API boundary and at wx interop
+// points (wxFFile streams, wxLog formatting). The two helpers below
+// encode the platform-conditional UTF-8 / wide-char split in one place.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] auto toPath(const wxString& str) -> fs::path {
+#ifdef __WXMSW__
+    return fs::path { str.ToStdWstring() };
+#else
+    return fs::path { str.ToStdString(wxConvUTF8) };
+#endif
+}
+
+[[nodiscard]] auto toWx(const fs::path& path) -> wxString {
+#ifdef __WXMSW__
+    return wxString { path.wstring() };
+#else
+    return wxString::FromUTF8(path.string());
+#endif
+}
+
 void dismissSplash() {
     auto node = wxTopLevelWindows.GetFirst();
     while (node) {
@@ -41,30 +67,21 @@ namespace {
 constexpr auto kReadOnlySentinel = "READONLY";
 
 /// True when the IDE resources directory carries the read-only sentinel.
-auto hasReadOnlySentinel(const wxString& dir) -> bool {
-    const wxFileName marker(dir, kReadOnlySentinel);
-    return marker.FileExists();
+[[nodiscard]] auto hasReadOnlySentinel(const fs::path& dir) -> bool {
+    std::error_code ec;
+    return fs::exists(dir / kReadOnlySentinel, ec);
 }
-} // namespace
 
-namespace {
 /// True when `lhs` and `rhs` refer to the same filesystem entry.
-/// Follows symlinks on both sides via std::filesystem::equivalent, so
+/// Follows symlinks on both sides via `std::filesystem::equivalent`, so
 /// editing a config file through a symlink still matches the loaded
 /// canonical path.
-auto samePath(const wxString& lhs, const wxString& rhs) -> bool {
+[[nodiscard]] auto samePath(const fs::path& lhs, const fs::path& rhs) -> bool {
     if (lhs.empty() || rhs.empty()) {
         return false;
     }
     std::error_code ec;
-#ifdef __WXMSW__
-    const std::filesystem::path lhsFs(lhs.ToStdWstring());
-    const std::filesystem::path rhsFs(rhs.ToStdWstring());
-#else
-    const std::filesystem::path lhsFs(lhs.ToStdString(wxConvUTF8));
-    const std::filesystem::path rhsFs(rhs.ToStdString(wxConvUTF8));
-#endif
-    return std::filesystem::equivalent(lhsFs, rhsFs, ec);
+    return fs::equivalent(lhs, rhs, ec);
 }
 } // namespace
 
@@ -121,17 +138,26 @@ void exportGroup(const Value& node, const wxString& path, wxFileConfig& cfg) {
 // ---------------------------------------------------------------------------
 
 namespace {
-auto enumerate(const wxString& base, const std::initializer_list<wxString> specs = { "*.ini" }) -> std::vector<wxString> {
-    std::vector<wxString> files;
-    for (const auto& spec : specs) {
-        if (const wxDir dir(base); dir.IsOpened()) {
-            wxString name;
-            bool more = dir.GetFirst(&name, spec, wxDIR_FILES);
-            while (more) {
-                wxFileName path { name };
-                path.MakeAbsolute(base);
-                files.emplace_back(path.GetFullPath());
-                more = dir.GetNext(&name);
+/// Enumerate regular files directly under `base` whose extension is in
+/// `exts` (with leading dot, e.g. `".ini"`). Returns absolute paths
+/// sorted by full path. Symlinks are followed via `directory_iterator`
+/// defaults, matching the symlink-aware semantics elsewhere in this TU.
+[[nodiscard]] auto enumerate(const fs::path& base, std::initializer_list<std::string_view> exts = { ".ini" }) -> std::vector<fs::path> {
+    std::vector<fs::path> files;
+    std::error_code ec;
+    const fs::directory_iterator it { base, ec };
+    if (ec) {
+        return files;
+    }
+    for (const auto& entry : it) {
+        if (!entry.is_regular_file(ec)) {
+            continue;
+        }
+        const auto ext = entry.path().extension().string();
+        for (const auto sv : exts) {
+            if (ext == sv) {
+                files.emplace_back(entry.path());
+                break;
             }
         }
     }
@@ -141,60 +167,79 @@ auto enumerate(const wxString& base, const std::initializer_list<wxString> specs
 } // namespace
 
 auto ConfigManager::getAllLanguages() const -> std::vector<wxString> {
-    return enumerate(m_ideDir / "locales");
+    const auto paths = enumerate(m_ideDir / "locales");
+    std::vector<wxString> out;
+    out.reserve(paths.size());
+    for (const auto& path : paths) {
+        out.push_back(toWx(path));
+    }
+    return out;
 }
 
 auto ConfigManager::getAllThemes() const -> std::vector<wxString> {
-    auto bundle = enumerate(m_ideDir / "themes", { "*.ini", "*.fbt" });
+    auto bundle = enumerate(m_ideDir / "themes", { ".ini", ".fbt" });
     if (!m_readOnlyIde) {
-        return bundle;
+        std::vector<wxString> out;
+        out.reserve(bundle.size());
+        for (const auto& path : bundle) {
+            out.push_back(toWx(path));
+        }
+        return out;
     }
-    auto user = enumerate(m_userDataDir / "themes", { "*.ini", "*.fbt" });
+    auto user = enumerate(m_userDataDir / "themes", { ".ini", ".fbt" });
 
     // Two-dir merge — user entries shadow bundle entries on basename
     // collision. `std::unordered_map` because the pch ships unordered
     // but not ordered map; sort by basename in a separate pass.
-    std::unordered_map<wxString, wxString> byName;
+    std::unordered_map<std::string, fs::path> byName;
     for (auto& path : bundle) {
-        byName[wxFileName(path).GetFullName()] = std::move(path);
+        byName[path.filename().string()] = std::move(path);
     }
     for (auto& path : user) {
-        byName[wxFileName(path).GetFullName()] = std::move(path);
+        byName[path.filename().string()] = std::move(path);
     }
-    std::vector<wxString> merged;
+    std::vector<fs::path> merged;
     merged.reserve(byName.size());
     for (auto& value : std::views::values(byName)) {
         merged.push_back(std::move(value));
     }
-    std::ranges::sort(merged, [](const wxString& lhs, const wxString& rhs) {
-        return wxFileName(lhs).GetFullName() < wxFileName(rhs).GetFullName();
+    std::ranges::sort(merged, [](const fs::path& lhs, const fs::path& rhs) {
+        return lhs.filename() < rhs.filename();
     });
-    return merged;
+    std::vector<wxString> out;
+    out.reserve(merged.size());
+    for (const auto& path : merged) {
+        out.push_back(toWx(path));
+    }
+    return out;
 }
 
 auto ConfigManager::themesWriteDir() const -> wxString {
     const auto dir = (m_readOnlyIde ? m_userDataDir : m_ideDir) / "themes";
-    wxFileName::Mkdir(dir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-    return dir;
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    return toWx(dir);
 }
 
 auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
     if (relPath.empty()) {
         return relPath;
     }
-    if (const wxFileName fn { relPath }; fn.IsAbsolute()) {
-        return fn.GetAbsolutePath();
+    const auto rel = toPath(relPath);
+    if (rel.is_absolute()) {
+        return toWx(rel.lexically_normal());
     }
-    // READONLY: user override at `<UserDataDir>/<relPath>` wins. Probed
+    // READONLY: user override at `<UserDataDir>/<rel>` wins. Probed
     // before the generic `absolute()` walk so a same-named bundle theme
     // never shadows the user's edit.
     if (m_readOnlyIde) {
-        const wxString candidate = m_userDataDir / relPath;
-        if (wxFileExists(candidate)) {
-            return wxFileName(candidate).GetAbsolutePath();
+        std::error_code ec;
+        const auto candidate = (m_userDataDir / rel).lexically_normal();
+        if (fs::exists(candidate, ec)) {
+            return toWx(candidate);
         }
     }
-    return absolute(relPath);
+    return toWx(absolutePath(rel));
 }
 
 auto ConfigManager::getPlatformConfigFileName() -> wxString {
@@ -252,34 +297,38 @@ ConfigManager::ConfigManager(
     const wxString& configPath,
     const wxString& userDataDirOverride
 )
-: m_appDir(appPath)
-, m_userDataDir(userDataDirOverride.empty() ? wxStandardPaths::Get().GetUserDataDir() : userDataDirOverride) {
-    if (not wxDirExists(appPath)) {
+: m_appDir(toPath(appPath))
+, m_userDataDir(toPath(userDataDirOverride.empty() ? wxStandardPaths::Get().GetUserDataDir() : userDataDirOverride)) {
+    // Normalise trailing-separator forms so `.filename()` returns the
+    // last segment (needed by the macOS bundle / AppImage detection
+    // below). fs::path treats `/foo/bar/` and `/foo/bar` differently —
+    // the former has an empty filename component.
+    if (!m_appDir.empty() && !m_appDir.has_filename()) {
+        m_appDir = m_appDir.parent_path();
+    }
+
+    std::error_code ec;
+    if (!fs::is_directory(m_appDir, ec)) {
         wxLogError("app directory '%s' does not exist", appPath);
         return;
     }
 
-    if (not idePath.empty()) {
-        const auto path = absolute(idePath);
-        if (wxDirExists(path)) {
+    if (!idePath.empty()) {
+        const auto path = absolutePath(toPath(idePath));
+        if (fs::is_directory(path, ec)) {
             m_ideDir = path;
         } else {
-            wxLogWarning("ide config directory '%s' does not exist", path);
+            wxLogWarning("ide config directory '%s' does not exist", toWx(path));
         }
     }
     if (m_ideDir.empty()) {
 #ifdef __WXOSX__
         // Prefer bundle Resources when running inside a macOS .app
-        wxFileName appPathFn(m_appDir, "");
-        const auto& dirs = appPathFn.GetDirs();
-        if (!dirs.empty() && dirs.back() == "MacOS") {
-            appPathFn.RemoveLastDir(); // MacOS -> Contents
-            const wxString contentsDir = appPathFn.GetPath();
-            const wxString bundleIde = contentsDir + "/Resources/ide";
-            if (wxDirExists(bundleIde)) {
+        if (m_appDir.filename() == "MacOS") {
+            const auto bundleIde = m_appDir.parent_path() / "Resources" / "ide";
+            if (fs::is_directory(bundleIde, ec)) {
                 m_ideDir = bundleIde;
             } else {
-                // Fallback if bundle layout not as expected
                 m_ideDir = m_appDir / "ide";
             }
         } else {
@@ -293,13 +342,9 @@ ConfigManager::ConfigManager(
         // binary location and look for share/fbide/ide; fall back to
         // the portable side-by-side layout if that directory is absent
         // (e.g. running from a build tree before `cmake --install`).
-        wxFileName appPathFn(m_appDir, "");
-        const auto& dirs = appPathFn.GetDirs();
-        if (!dirs.empty() && dirs.back() == "bin") {
-            appPathFn.RemoveLastDir();
-            const wxString prefix = appPathFn.GetPath();
-            const wxString fhsIde = prefix + "/share/fbide/ide";
-            if (wxDirExists(fhsIde)) {
+        if (m_appDir.filename() == "bin") {
+            const auto fhsIde = m_appDir.parent_path() / "share" / "fbide" / "ide";
+            if (fs::is_directory(fhsIde, ec)) {
                 m_ideDir = fhsIde;
             } else {
                 m_ideDir = m_appDir / "ide";
@@ -311,8 +356,8 @@ ConfigManager::ConfigManager(
         m_ideDir = m_appDir / "ide";
 #endif
     }
-    if (not wxDirExists(m_ideDir)) {
-        wxLogError("ide config directory '%s' does not exist", m_ideDir);
+    if (!fs::is_directory(m_ideDir, ec)) {
+        wxLogError("ide config directory '%s' does not exist", toWx(m_ideDir));
         return;
     }
 
@@ -326,15 +371,15 @@ ConfigManager::ConfigManager(
     m_explicitConfig = !configPath.empty();
     m_readOnlyIde = hasReadOnlySentinel(m_ideDir);
     if (m_readOnlyIde) {
-        wxLogMessage("READONLY sentinel detected in '%s' — overlays route to '%s'", m_ideDir, m_userDataDir);
+        wxLogMessage("READONLY sentinel detected in '%s' — overlays route to '%s'", toWx(m_ideDir), toWx(m_userDataDir));
     }
 
     auto& entry = m_categories.at(static_cast<std::size_t>(Category::Config));
     entry.strategy = buildStrategy(
         Category::Config,
-        absolute(configPath.empty() ? getPlatformConfigFileName() : configPath)
+        absolutePath(toPath(configPath.empty() ? getPlatformConfigFileName() : configPath))
     );
-    wxLogMessage("ide directory: %s", m_ideDir);
+    wxLogMessage("ide directory: %s", toWx(m_ideDir));
     load(Category::Config);
 
     // Load all configs
@@ -345,7 +390,7 @@ ConfigManager::ConfigManager(
     // Resolve + load theme immediately after config is available. If the
     // configured theme file is missing or absent, fall back to a built-in
     // minimal theme so the editor still launches with a usable scheme.
-    if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
+    if (const auto themeRel = config().get_or("theme", wxString {}); !themeRel.empty()) {
         const auto themeAbs = themePath(themeRel);
         if (wxFileExists(themeAbs)) {
             m_theme.load(themeAbs);
@@ -355,7 +400,7 @@ ConfigManager::ConfigManager(
             m_theme.loadDefaults();
         }
     } else {
-        wxLogWarning("No 'theme' entry found in config '%s' — using built-in default", entry.strategy.basePath());
+        wxLogWarning("No 'theme' entry found in config '%s' — using built-in default", toWx(entry.strategy.basePath()));
         m_theme.loadDefaults();
     }
 }
@@ -379,7 +424,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
     // unaffected here; full sub-category rebind is task #13 territory.
     m_explicitConfig = true;
     auto& entry = m_categories.at(static_cast<std::size_t>(Category::Config));
-    entry.strategy = buildStrategy(Category::Config, absolute(configPath));
+    entry.strategy = buildStrategy(Category::Config, absolutePath(toPath(configPath)));
     load(Category::Config);
 
     // Cascade — sub-categories were loaded under the prior mode (likely
@@ -390,7 +435,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
         load(cat);
     }
 
-    if (const auto themeRel = config().get_or("theme", wxString {}); not themeRel.empty()) {
+    if (const auto themeRel = config().get_or("theme", wxString {}); !themeRel.empty()) {
         const auto themeAbs = themePath(themeRel);
         if (wxFileExists(themeAbs)) {
             m_theme.load(themeAbs);
@@ -407,7 +452,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
 // Strategy
 // ---------------------------------------------------------------------------
 
-auto ConfigManager::buildStrategy(const Category category, const wxString& basePath) const -> ConfigStrategy {
+auto ConfigManager::buildStrategy(const Category category, const fs::path& basePath) const -> ConfigStrategy {
     // Locale is the only bundle-only mutable slot (custom locales come
     // from a user-set `locale=<path>` in the config overlay, not from an
     // overlay of the locale file itself). Everything else is overlay-
@@ -424,7 +469,7 @@ void ConfigManager::load(const Category category) {
     auto& entry = m_categories.at(static_cast<std::size_t>(category));
     const auto catView = getCategoryName(category);
     const wxString catName { catView.data(), catView.size() };
-    wxString file;
+    fs::path file;
 
     if (category == Category::Config) {
         // Strategy already built by ctor / reloadConfig before they
@@ -439,18 +484,19 @@ void ConfigManager::load(const Category category) {
             wxLogError("Config category '%s' missing or invalid", catName);
             return;
         }
-        file = absolute(*relPath);
+        file = absolutePath(toPath(*relPath));
         entry.strategy = buildStrategy(category, file);
     }
 
-    if (!wxFileExists(file)) {
+    std::error_code ec;
+    if (!fs::exists(file, ec)) {
         // Per-category recovery for missing files. Config + Layout are
         // load-bearing for the rest of the IDE, so a miss is fatal —
         // every other path falls back to a workable empty / default
         // state and lets the app keep going.
         wxLogError(
             "Config file '%s' for '%s' category not found",
-            file, catName
+            toWx(file), catName
         );
         switch (category) {
         case Category::Config:
@@ -459,7 +505,7 @@ void ConfigManager::load(const Category category) {
                     "FBIde could not start: the main configuration file was not found.\n\n"
                     "Expected at:\n%s\n\n"
                     "Reinstall FBIde or supply --config=<path>.",
-                    file
+                    toWx(file)
                 )
             );
         case Category::Layout:
@@ -468,7 +514,7 @@ void ConfigManager::load(const Category category) {
                     "FBIde could not start: the layout file was not found.\n\n"
                     "Expected at:\n%s\n\n"
                     "Reinstall FBIde or restore the layout.ini next to the IDE resources.",
-                    file
+                    toWx(file)
                 )
             );
         case Category::Locale:
@@ -481,7 +527,7 @@ void ConfigManager::load(const Category category) {
                     "FBIde could not start: the locale file was not found.\n\n"
                     "Expected at:\n%s\n\n"
                     "Reinstall FBIde or restore the locales directory next to the IDE resources.",
-                    file
+                    toWx(file)
                 )
             );
         case Category::Keywords:
@@ -494,9 +540,10 @@ void ConfigManager::load(const Category category) {
         return;
     }
 
-    wxFFileInputStream stream(file);
+    const auto fileWx = toWx(file);
+    wxFFileInputStream stream(fileWx);
     if (!stream.IsOk()) {
-        wxLogError("Failed to open '%s' for reading", file);
+        wxLogError("Failed to open '%s' for reading", fileWx);
         return;
     }
 
@@ -517,27 +564,25 @@ void ConfigManager::load(const Category category) {
     // Overlay merge — only when the strategy provides an overlay path
     // and that file actually exists. Missing overlay is fine; it just
     // means the user has no divergences from bundle yet.
-    if (entry.strategy.usesOverlay() && wxFileExists(entry.strategy.overlayPath())) {
-        wxFFileInputStream overlayStream(entry.strategy.overlayPath());
+    if (entry.strategy.usesOverlay() && fs::exists(entry.strategy.overlayPath(), ec)) {
+        const auto overlayWx = toWx(entry.strategy.overlayPath());
+        wxFFileInputStream overlayStream(overlayWx);
         if (overlayStream.IsOk()) {
             wxFileConfig overlayCfg(overlayStream, wxConvUTF8);
             Value overlay;
             overlayCfg.SetPath("/");
             importGroup(overlayCfg, overlay);
             root.mergeFrom(overlay);
-            wxLogMessage(
-                "Merged overlay %s into %s",
-                entry.strategy.overlayPath(), catName
-            );
+            wxLogMessage("Merged overlay %s into %s", overlayWx, catName);
         } else {
-            wxLogWarning("Overlay '%s' exists but could not be read", entry.strategy.overlayPath());
+            wxLogWarning("Overlay '%s' exists but could not be read", overlayWx);
         }
     }
 
     entry.category = category;
     entry.baseline = std::move(baseline);
     entry.root = std::move(root);
-    wxLogMessage("Loaded %s from %s", catName, file);
+    wxLogMessage("Loaded %s from %s", catName, fileWx);
 }
 
 void ConfigManager::save(const Category category) const {
@@ -566,26 +611,28 @@ void ConfigManager::save(const Category category) const {
         // fresh from the diff rather than merging into existing keys so
         // stale entries from prior saves don't accumulate.
         const auto& overlayPath = entry.strategy.overlayPath();
+        const auto overlayWx = toWx(overlayPath);
+        std::error_code ec;
         const auto diff = entry.root.diffAgainst(entry.baseline);
         if (!diff) {
-            if (wxFileExists(overlayPath)) {
-                wxRemoveFile(overlayPath);
-                wxLogMessage("Pruned empty overlay '%s'", overlayPath);
+            if (fs::exists(overlayPath, ec)) {
+                fs::remove(overlayPath, ec);
+                wxLogMessage("Pruned empty overlay '%s'", overlayWx);
             }
             return;
         }
         // Ensure parent dir exists — under READONLY this is
         // `<UserDataDir>` which may not exist on first launch.
-        wxFileName::Mkdir(wxFileName(overlayPath).GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+        fs::create_directories(overlayPath.parent_path(), ec);
         wxFileConfig overlayCfg;
-        wxFFileOutputStream outStream(overlayPath);
+        wxFFileOutputStream outStream(overlayWx);
         if (!outStream.IsOk()) {
-            wxLogError("Failed to open '%s' for writing", overlayPath);
+            wxLogError("Failed to open '%s' for writing", overlayWx);
             return;
         }
         exportGroup(diff, "", overlayCfg);
         overlayCfg.Save(outStream, wxConvUTF8);
-        wxLogMessage("Saved overlay '%s'", overlayPath);
+        wxLogMessage("Saved overlay '%s'", overlayWx);
         return;
     }
 
@@ -594,12 +641,12 @@ void ConfigManager::save(const Category category) const {
     // its constructor (preserves comments + ordering), then we truncate
     // the file for writing. Reversing the order would zero the file
     // before parsing completed.
-    const auto& savePath = entry.strategy.savePath();
-    wxFileInputStream existingStream(savePath);
+    const auto savePathWx = toWx(entry.strategy.savePath());
+    wxFileInputStream existingStream(savePathWx);
     wxFileConfig cfg(existingStream, wxConvUTF8);
-    wxFFileOutputStream outStream(savePath);
+    wxFFileOutputStream outStream(savePathWx);
     if (!outStream.IsOk()) {
-        wxLogError("Failed to open '%s' for writing", savePath);
+        wxLogError("Failed to open '%s' for writing", savePathWx);
         return;
     }
 
@@ -608,14 +655,15 @@ void ConfigManager::save(const Category category) const {
 }
 
 auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
+    const auto target = toPath(path);
     for (std::size_t index = 0; index < CAT_COUNT; index++) {
         const auto& entry = m_categories.at(index);
         // Trigger reload when the user touches either side of the
         // layered pair — the bundle base (rare; usually requires elevated
         // perms inside a bundle) or the writable overlay.
-        const bool baseMatch = samePath(path, entry.strategy.basePath());
+        const bool baseMatch = samePath(target, entry.strategy.basePath());
         const bool overlayMatch = entry.strategy.usesOverlay()
-                               && samePath(path, entry.strategy.overlayPath());
+                               && samePath(target, entry.strategy.overlayPath());
         if (baseMatch || overlayMatch) {
             load(entry.category);
             // if this was config, then reload all other files as well.
@@ -623,7 +671,7 @@ auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
                 for (std::size_t sub = 1; sub < CAT_COUNT; sub++) {
                     load(m_categories.at(sub).category);
                 }
-                if (const auto themeRel = config().get_or("theme", ""); not themeRel.empty()) {
+                if (const auto themeRel = config().get_or("theme", ""); !themeRel.empty()) {
                     m_theme.load(themePath(themeRel));
                 }
             }
@@ -633,7 +681,7 @@ auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
 
     // Theme reload requires a copied path — Theme::load(path) resets the
     // object and then assigns the incoming path back into m_themePath.
-    if (const auto currentThemePath = m_theme.getPath(); samePath(path, currentThemePath)) {
+    if (const auto currentThemePath = m_theme.getPath(); samePath(target, toPath(currentThemePath))) {
         m_theme.load(currentThemePath);
         return true;
     }
@@ -655,7 +703,7 @@ namespace {
 /// Returns empty when `glob` is empty. Falls back to `key` for the
 /// description when the locale entry is missing so translation gaps
 /// are visible in the dialog.
-auto composeFilter(const wxString& key, const wxString& desc, const wxString& glob) -> wxString {
+[[nodiscard]] auto composeFilter(const wxString& key, const wxString& desc, const wxString& glob) -> wxString {
     if (glob.IsEmpty()) {
         return {};
     }
@@ -693,63 +741,76 @@ auto ConfigManager::filePatterns(const std::initializer_list<std::string_view> k
 // Path handling
 // ---------------------------------------------------------------------------
 
+auto ConfigManager::getAppDir() const -> wxString {
+    return toWx(m_appDir);
+}
+
+auto ConfigManager::getIdeDir() const -> wxString {
+    return toWx(m_ideDir);
+}
+
 auto ConfigManager::absolute(const wxString& pathName) const -> wxString {
-    wxFileName path(pathName);
-    path.Normalize(wxPATH_NORM_ENV_VARS | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_SHORTCUT);
+    return toWx(absolutePath(toPath(pathName)));
+}
 
-    if (path.IsAbsolute()) {
-        return path.GetAbsolutePath();
+auto ConfigManager::absolutePath(const fs::path& rel) const -> fs::path {
+    if (rel.is_absolute()) {
+        return rel.lexically_normal();
     }
 
-    wxFileName fn(path);
-
-    fn.MakeAbsolute(m_ideDir);
-    if (fn.Exists()) {
-        return fn.GetAbsolutePath();
+    // Walk candidate bases: ide → app → cwd. Preserves the order the
+    // legacy wxFileName-based resolver used; user-themes-dir precedence
+    // is handled separately by `themePath()`. `lexically_normal`
+    // resolves `.` and `..` segments without touching the filesystem
+    // (so it doesn't canonicalise symlinks — matches prior behaviour
+    // and keeps user-visible paths in the form the user supplied).
+    std::error_code ec;
+    const std::array bases { m_ideDir, m_appDir, fs::current_path(ec) };
+    for (const auto& base : bases) {
+        if (base.empty()) {
+            continue;
+        }
+        const auto candidate = (base / rel).lexically_normal();
+        if (fs::exists(candidate, ec)) {
+            return candidate;
+        }
     }
 
-    fn = path;
-    fn.MakeAbsolute(m_appDir);
-    if (fn.Exists()) {
-        return fn.GetAbsolutePath();
-    }
-
-    fn = path;
-    fn.MakeAbsolute(wxGetCwd());
-    if (fn.Exists()) {
-        return fn.GetAbsolutePath();
-    }
-
-    wxLogError("Failed to resolve absolute path %s", pathName);
-    return pathName;
+    wxLogError("Failed to resolve absolute path %s", toWx(rel));
+    return rel;
 }
 
 namespace {
-auto makeRelative(const wxString& path, const wxString& to) -> std::optional<wxString> {
-    if (to.StartsWith(path)) {
-        wxFileName result(to);
-        result.MakeRelativeTo(path);
-        return result.GetFullPath(wxPATH_UNIX);
+/// Make `abs` relative to `base` iff `abs` is actually under `base`.
+/// Returns empty optional when `abs` is on a different subtree (so the
+/// caller can fall through to the next candidate base). Uses
+/// `lexically_relative` which doesn't touch the filesystem.
+[[nodiscard]] auto makeRelative(const fs::path& base, const fs::path& abs) -> std::optional<fs::path> {
+    if (base.empty()) {
+        return std::nullopt;
     }
-    return {};
+    auto rel = abs.lexically_relative(base);
+    if (rel.empty() || *rel.begin() == "..") {
+        return std::nullopt;
+    }
+    return rel;
 }
 } // namespace
 
 auto ConfigManager::relative(const wxString& path) const -> wxString {
-    const auto abs = absolute(path);
+    const auto abs = absolutePath(toPath(path));
     // Candidate base dirs, in priority order:
     // - m_ideDir       — bundle resources.
-    // - m_userDataDir  — writable equivalent of ide/ (always populated;
-    //                    ctor falls back to wxStandardPaths when no
-    //                    override). A path like `<userDataDir>/themes/
-    //                    dark.ini` must stringify the same as the
-    //                    bundle equivalent so themePath() round-trips
-    //                    correctly on the next load.
+    // - m_userDataDir  — writable equivalent of ide/. A path like
+    //                    `<userDataDir>/themes/dark.ini` must stringify
+    //                    the same as the bundle equivalent so
+    //                    themePath() round-trips correctly on the next
+    //                    load.
     // - m_appDir       — binary directory; fallback for portable
     //                    side-by-side layouts.
     for (const auto* base : { &m_ideDir, &m_userDataDir, &m_appDir }) {
         if (const auto rel = makeRelative(*base, abs)) {
-            return *rel;
+            return toWx(rel->generic_string());
         }
     }
     return path;

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -718,6 +718,17 @@ auto ConfigManager::relative(const wxString& path) const -> wxString {
     if (const auto ide = makeRelative(m_ideDir, abs)) {
         return *ide;
     }
+    // User data dir under READONLY is the writable equivalent of the
+    // bundle's ide/ — a path like `<UserDataDir>/themes/dark.ini`
+    // belongs to the same logical layout and must stringify as the same
+    // relative form so `themePath()` round-trips correctly on the next
+    // load. Without this, theme saves under READONLY leaked absolute
+    // paths into `config["theme"]`.
+    if (!m_userDataDir.empty()) {
+        if (const auto userData = makeRelative(m_userDataDir, abs)) {
+            return *userData;
+        }
+    }
     if (const auto app = makeRelative(m_appDir, abs)) {
         return *app;
     }

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -536,6 +536,16 @@ void ConfigManager::load(const Category category) {
 }
 
 void ConfigManager::save(const Category category) {
+    // Locale is bundle-only. The IDE never writes its translation strings
+    // back; any caller asking for `save(Locale)` is a bug — flag loudly
+    // rather than silently truncating the bundle locale file under
+    // portable mode (or no-op'ing under READONLY where the write would
+    // fail anyway).
+    if (category == Category::Locale) {
+        wxLogError("save(Locale) refused — locale files are bundle-only");
+        return;
+    }
+
     const auto& entry = m_categories[static_cast<std::size_t>(category)];
     if (entry.category != category) {
         wxLogWarning("Trying to save unloaded category '%s'", getCategoryName(category).data());
@@ -613,8 +623,8 @@ auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
 
     // Theme reload requires a copied path — Theme::load(path) resets the
     // object and then assigns the incoming path back into m_themePath.
-    if (const auto themePath = m_theme.getPath(); samePath(path, themePath)) {
-        m_theme.load(themePath);
+    if (const auto currentThemePath = m_theme.getPath(); samePath(path, currentThemePath)) {
+        m_theme.load(currentThemePath);
         return true;
     }
 
@@ -718,16 +728,15 @@ auto ConfigManager::relative(const wxString& path) const -> wxString {
     if (const auto ide = makeRelative(m_ideDir, abs)) {
         return *ide;
     }
-    // User data dir under READONLY is the writable equivalent of the
-    // bundle's ide/ — a path like `<UserDataDir>/themes/dark.ini`
-    // belongs to the same logical layout and must stringify as the same
-    // relative form so `themePath()` round-trips correctly on the next
-    // load. Without this, theme saves under READONLY leaked absolute
-    // paths into `config["theme"]`.
-    if (!m_userDataDir.empty()) {
-        if (const auto userData = makeRelative(m_userDataDir, abs)) {
-            return *userData;
-        }
+    // User data dir is the writable equivalent of the bundle's ide/ —
+    // a path like `<UserDataDir>/themes/dark.ini` belongs to the same
+    // logical layout and must stringify as the same relative form so
+    // `themePath()` round-trips correctly on the next load. Without
+    // this, theme saves under READONLY leaked absolute paths into
+    // `config["theme"]`. `m_userDataDir` is always populated (ctor
+    // falls back to `wxStandardPaths` when no override) so no guard.
+    if (const auto userData = makeRelative(m_userDataDir, abs)) {
+        return *userData;
     }
     if (const auto app = makeRelative(m_appDir, abs)) {
         return *app;

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -42,7 +42,7 @@ constexpr auto kReadOnlySentinel = "READONLY";
 
 /// True when the IDE resources directory carries the read-only sentinel.
 auto hasReadOnlySentinel(const wxString& dir) -> bool {
-    wxFileName marker(dir, kReadOnlySentinel);
+    const wxFileName marker(dir, kReadOnlySentinel);
     return marker.FileExists();
 }
 } // namespace
@@ -126,12 +126,12 @@ auto enumerate(const wxString& base, const std::initializer_list<wxString> specs
     for (const auto& spec : specs) {
         if (const wxDir dir(base); dir.IsOpened()) {
             wxString name;
-            if (dir.GetFirst(&name, spec, wxDIR_FILES)) {
-                do {
-                    wxFileName path { name };
-                    path.MakeAbsolute(base);
-                    files.emplace_back(path.GetFullPath());
-                } while (dir.GetNext(&name));
+            bool more = dir.GetFirst(&name, spec, wxDIR_FILES);
+            while (more) {
+                wxFileName path { name };
+                path.MakeAbsolute(base);
+                files.emplace_back(path.GetFullPath());
+                more = dir.GetNext(&name);
             }
         }
     }
@@ -166,8 +166,8 @@ auto ConfigManager::getAllThemes() const -> std::vector<wxString> {
     for (auto& value : std::views::values(byName)) {
         merged.push_back(std::move(value));
     }
-    std::ranges::sort(merged, [](const wxString& a, const wxString& b) {
-        return wxFileName(a).GetFullName() < wxFileName(b).GetFullName();
+    std::ranges::sort(merged, [](const wxString& lhs, const wxString& rhs) {
+        return wxFileName(lhs).GetFullName() < wxFileName(rhs).GetFullName();
     });
     return merged;
 }
@@ -182,7 +182,7 @@ auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
     if (relPath.empty()) {
         return relPath;
     }
-    if (wxFileName fn { relPath }; fn.IsAbsolute()) {
+    if (const wxFileName fn { relPath }; fn.IsAbsolute()) {
         return fn.GetAbsolutePath();
     }
     // READONLY: user override at `<UserDataDir>/<relPath>` wins. Probed
@@ -200,7 +200,7 @@ auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
 auto ConfigManager::getPlatformConfigFileName() -> wxString {
 #ifdef __WXMSW__
     return "config_win.ini";
-#elif defined(__WXOSX__)
+#elifdef __WXOSX__
     return "config_macos.ini";
 #else
     return "config_linux.ini";
@@ -210,7 +210,7 @@ auto ConfigManager::getPlatformConfigFileName() -> wxString {
 auto ConfigManager::getTerminal() -> wxString {
 #ifdef __WXMSW__
     return "cmd.exe";
-#elif defined(__WXOSX__)
+#elifdef __WXOSX__
     return "open -a Terminal";
 #else
     return "x-terminal-emulator";
@@ -229,7 +229,7 @@ auto ConfigManager::getDefaultTerminalLauncher() -> wxString {
     // Keeping cmd in the foreground (no `start`) means kill / Stop
     // cascades through cmd's process group to the child program.
     return "cmd /C";
-#elif defined(__WXOSX__)
+#elifdef __WXOSX__
     // TODO: Terminal.app does not accept the program as a CLI argument;
     // launching requires AppleScript via `osascript` or a temp `.command`
     // script. Cannot be expressed as a single-line template prefix.
@@ -286,7 +286,7 @@ ConfigManager::ConfigManager(
             // Not in a bundle (e.g., running from build dir)
             m_ideDir = m_appDir / "ide";
         }
-#elif defined(FBIDE_APPIMAGE_BUILD)
+#elifdef FBIDE_APPIMAGE_BUILD
         // FHS layout used by AppImage / future deb / rpm packages: the
         // binary lives at <prefix>/bin/fbide and resources at
         // <prefix>/share/fbide/ide. Walk one directory up from the
@@ -329,7 +329,7 @@ ConfigManager::ConfigManager(
         wxLogMessage("READONLY sentinel detected in '%s' — overlays route to '%s'", m_ideDir, m_userDataDir);
     }
 
-    auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
+    auto& entry = m_categories.at(static_cast<std::size_t>(Category::Config));
     entry.strategy = buildStrategy(
         Category::Config,
         absolute(configPath.empty() ? getPlatformConfigFileName() : configPath)
@@ -378,7 +378,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
     // `Direct`. Sub-categories already loaded under prior mode are
     // unaffected here; full sub-category rebind is task #13 territory.
     m_explicitConfig = true;
-    auto& entry = m_categories[static_cast<std::size_t>(Category::Config)];
+    auto& entry = m_categories.at(static_cast<std::size_t>(Category::Config));
     entry.strategy = buildStrategy(Category::Config, absolute(configPath));
     load(Category::Config);
 
@@ -407,7 +407,7 @@ void ConfigManager::reloadConfig(const wxString& configPath) {
 // Strategy
 // ---------------------------------------------------------------------------
 
-auto ConfigManager::buildStrategy(const Category category, wxString basePath) const -> ConfigStrategy {
+auto ConfigManager::buildStrategy(const Category category, const wxString& basePath) const -> ConfigStrategy {
     // Locale is the only bundle-only mutable slot (custom locales come
     // from a user-set `locale=<path>` in the config overlay, not from an
     // overlay of the locale file itself). Everything else is overlay-
@@ -421,7 +421,9 @@ auto ConfigManager::buildStrategy(const Category category, wxString basePath) co
 // ---------------------------------------------------------------------------
 
 void ConfigManager::load(const Category category) {
-    auto& entry = m_categories[static_cast<std::size_t>(category)];
+    auto& entry = m_categories.at(static_cast<std::size_t>(category));
+    const auto catView = getCategoryName(category);
+    const wxString catName { catView.data(), catView.size() };
     wxString file;
 
     if (category == Category::Config) {
@@ -431,11 +433,10 @@ void ConfigManager::load(const Category category) {
         // path resolution.
         file = entry.strategy.basePath();
     } else {
-        const auto key = getCategoryName(category);
-        const auto& ref = config().at({ key.data(), key.size() });
+        const auto& ref = config().at(catName);
         const auto relPath = ref.as<wxString>();
         if (!relPath.has_value() || relPath->empty()) {
-            wxLogError("Config category '%s' missing or invalid", key.data());
+            wxLogError("Config category '%s' missing or invalid", catName);
             return;
         }
         file = absolute(*relPath);
@@ -447,10 +448,9 @@ void ConfigManager::load(const Category category) {
         // load-bearing for the rest of the IDE, so a miss is fatal —
         // every other path falls back to a workable empty / default
         // state and lets the app keep going.
-        const auto catName = getCategoryName(category);
         wxLogError(
             "Config file '%s' for '%s' category not found",
-            file, catName.data()
+            file, catName
         );
         switch (category) {
         case Category::Config:
@@ -527,7 +527,7 @@ void ConfigManager::load(const Category category) {
             root.mergeFrom(overlay);
             wxLogMessage(
                 "Merged overlay %s into %s",
-                entry.strategy.overlayPath(), getCategoryName(category).data()
+                entry.strategy.overlayPath(), catName
             );
         } else {
             wxLogWarning("Overlay '%s' exists but could not be read", entry.strategy.overlayPath());
@@ -537,7 +537,7 @@ void ConfigManager::load(const Category category) {
     entry.category = category;
     entry.baseline = std::move(baseline);
     entry.root = std::move(root);
-    wxLogMessage("Loaded %s from %s", getCategoryName(category).data(), file);
+    wxLogMessage("Loaded %s from %s", catName, file);
 }
 
 void ConfigManager::save(const Category category) {
@@ -551,9 +551,11 @@ void ConfigManager::save(const Category category) {
         return;
     }
 
-    const auto& entry = m_categories[static_cast<std::size_t>(category)];
+    const auto& entry = m_categories.at(static_cast<std::size_t>(category));
     if (entry.category != category) {
-        wxLogWarning("Trying to save unloaded category '%s'", getCategoryName(category).data());
+        const auto catView = getCategoryName(category);
+        const wxString catName { catView.data(), catView.size() };
+        wxLogWarning("Trying to save unloaded category '%s'", catName);
         return;
     }
 
@@ -607,7 +609,7 @@ void ConfigManager::save(const Category category) {
 
 auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
     for (std::size_t index = 0; index < CAT_COUNT; index++) {
-        const auto& entry = m_categories[index];
+        const auto& entry = m_categories.at(index);
         // Trigger reload when the user touches either side of the
         // layered pair — the bundle base (rare; usually requires elevated
         // perms inside a bundle) or the writable overlay.
@@ -619,7 +621,7 @@ auto ConfigManager::reloadIfKnown(const wxString& path) -> bool {
             // if this was config, then reload all other files as well.
             if (entry.category == Category::Config) {
                 for (std::size_t sub = 1; sub < CAT_COUNT; sub++) {
-                    load(m_categories[sub].category);
+                    load(m_categories.at(sub).category);
                 }
                 if (const auto themeRel = config().get_or("theme", ""); not themeRel.empty()) {
                     m_theme.load(themePath(themeRel));

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -48,22 +48,23 @@ auto hasReadOnlySentinel(const wxString& dir) -> bool {
 } // namespace
 
 namespace {
-/// True when `a` and `b` refer to the same filesystem entry. Follows
-/// symlinks on both sides via std::filesystem::equivalent, so editing a
-/// config file through a symlink still matches the loaded canonical path.
-auto samePath(const wxString& a, const wxString& b) -> bool {
-    if (a.empty() || b.empty()) {
+/// True when `lhs` and `rhs` refer to the same filesystem entry.
+/// Follows symlinks on both sides via std::filesystem::equivalent, so
+/// editing a config file through a symlink still matches the loaded
+/// canonical path.
+auto samePath(const wxString& lhs, const wxString& rhs) -> bool {
+    if (lhs.empty() || rhs.empty()) {
         return false;
     }
     std::error_code ec;
 #ifdef __WXMSW__
-    const std::filesystem::path fa(a.ToStdWstring());
-    const std::filesystem::path fb(b.ToStdWstring());
+    const std::filesystem::path lhsFs(lhs.ToStdWstring());
+    const std::filesystem::path rhsFs(rhs.ToStdWstring());
 #else
-    const std::filesystem::path fa(a.ToStdString(wxConvUTF8));
-    const std::filesystem::path fb(b.ToStdString(wxConvUTF8));
+    const std::filesystem::path lhsFs(lhs.ToStdString(wxConvUTF8));
+    const std::filesystem::path rhsFs(rhs.ToStdString(wxConvUTF8));
 #endif
-    return std::filesystem::equivalent(fa, fb, ec);
+    return std::filesystem::equivalent(lhsFs, rhsFs, ec);
 }
 } // namespace
 
@@ -119,7 +120,8 @@ void exportGroup(const Value& node, const wxString& path, wxFileConfig& cfg) {
 // Get info
 // ---------------------------------------------------------------------------
 
-static auto enumerate(const wxString& base, const std::initializer_list<wxString> specs = { "*.ini" }) -> std::vector<wxString> {
+namespace {
+auto enumerate(const wxString& base, const std::initializer_list<wxString> specs = { "*.ini" }) -> std::vector<wxString> {
     std::vector<wxString> files;
     for (const auto& spec : specs) {
         if (const wxDir dir(base); dir.IsOpened()) {
@@ -136,6 +138,7 @@ static auto enumerate(const wxString& base, const std::initializer_list<wxString
     std::ranges::sort(files);
     return files;
 }
+} // namespace
 
 auto ConfigManager::getAllLanguages() const -> std::vector<wxString> {
     return enumerate(m_ideDir / "locales");
@@ -714,7 +717,8 @@ auto ConfigManager::absolute(const wxString& pathName) const -> wxString {
     return pathName;
 }
 
-static auto makeRelative(const wxString& path, const wxString& to) -> std::optional<wxString> {
+namespace {
+auto makeRelative(const wxString& path, const wxString& to) -> std::optional<wxString> {
     if (to.StartsWith(path)) {
         wxFileName result(to);
         result.MakeRelativeTo(path);
@@ -722,6 +726,7 @@ static auto makeRelative(const wxString& path, const wxString& to) -> std::optio
     }
     return {};
 }
+} // namespace
 
 auto ConfigManager::relative(const wxString& path) const -> wxString {
     const auto abs = absolute(path);

--- a/src/lib/config/ConfigManager.cpp
+++ b/src/lib/config/ConfigManager.cpp
@@ -169,6 +169,10 @@ auto ConfigManager::getAllThemes() const -> std::vector<wxString> {
     return merged;
 }
 
+auto ConfigManager::themesWriteDir() const -> wxString {
+    return (m_readOnlyIde ? m_userDataDir : m_ideDir) / "themes";
+}
+
 auto ConfigManager::themePath(const wxString& relPath) const -> wxString {
     if (relPath.empty()) {
         return relPath;

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -135,7 +135,7 @@ public:
     void reloadConfig(const wxString& configPath);
 
     /// Save the category's Value tree to its backing file.
-    void save(Category category);
+    void save(Category category)const;
 
     /// Reload any loaded config category or the active theme whose backing
     /// file matches `path`. Returns true when a reload occurred. Use to

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -85,9 +85,10 @@ public:
     /// override exists. Absolute paths are returned as-is.
     [[nodiscard]] auto themePath(const wxString& relPath) const -> wxString;
 
-    /// Directory theme files are written to. Under READONLY this is
-    /// `<UserDataDir>/themes/`; otherwise `<ideDir>/themes/`. Callers
-    /// are responsible for creating it on demand before saving.
+    /// Directory theme files are written to, created if missing. Under
+    /// READONLY this is `<UserDataDir>/themes/`; otherwise
+    /// `<ideDir>/themes/`. Always safe to call before a theme write —
+    /// `wxFileName::Mkdir(..., wxPATH_MKDIR_FULL)` is idempotent.
     [[nodiscard]] auto themesWriteDir() const -> wxString;
 
     /// Platform default config file name.

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -135,7 +135,7 @@ public:
     void reloadConfig(const wxString& configPath);
 
     /// Save the category's Value tree to its backing file.
-    void save(Category category)const;
+    void save(Category category) const;
 
     /// Reload any loaded config category or the active theme whose backing
     /// file matches `path`. Returns true when a reload occurred. Use to
@@ -152,9 +152,9 @@ public:
     [[nodiscard]] auto relative(const wxString& path) const -> wxString;
 
     /// Application directory (resolved from `appPath` argument).
-    [[nodiscard]] auto getAppDir() const -> const wxString& { return m_appDir; }
+    [[nodiscard]] auto getAppDir() const -> wxString;
     /// IDE resources directory (e.g. `<appDir>/ide` by default).
-    [[nodiscard]] auto getIdeDir() const -> const wxString& { return m_ideDir; }
+    [[nodiscard]] auto getIdeDir() const -> wxString;
 
     // -----------------------------------------------------------------------
     // Category accessors — return a reference to the category root Value.
@@ -206,7 +206,12 @@ private:
     /// Uses `m_userDataDir`, `m_readOnlyIde`, `m_explicitConfig` so callers
     /// (ctor + `load()` for sub-categories + `reloadConfig` / `setCategoryPath`)
     /// share the same rules.
-    [[nodiscard]] auto buildStrategy(Category category, const wxString& basePath) const -> ConfigStrategy;
+    [[nodiscard]] auto buildStrategy(Category category, const std::filesystem::path& basePath) const -> ConfigStrategy;
+
+    /// Resolve `rel` to an absolute path, walking the same ide → app →
+    /// cwd chain as the public `absolute()`. Used internally to avoid
+    /// the round-trip through `wxString`.
+    [[nodiscard]] auto absolutePath(const std::filesystem::path& rel) const -> std::filesystem::path;
 
     /// Per-category bookkeeping: storage policy + parsed trees.
     struct Entry final {
@@ -218,9 +223,9 @@ private:
     /// Number of categories — one slot per `Category` enum value.
     static constexpr std::size_t CAT_COUNT = 5;
 
-    wxString m_appDir {};                         ///< App directory (binary location).
-    wxString m_ideDir {};                         ///< IDE resources directory.
-    wxString m_userDataDir {};                    ///< User-writable dir for overlays + theme copies (READONLY mode).
+    std::filesystem::path m_appDir;               ///< App directory (binary location).
+    std::filesystem::path m_ideDir;               ///< IDE resources directory.
+    std::filesystem::path m_userDataDir;          ///< User-writable dir for overlays + theme copies (READONLY mode).
     bool m_readOnlyIde { false };                 ///< True when `READONLY` sentinel routes overlays to `m_userDataDir`.
     bool m_explicitConfig { false };              ///< True when `--config=PATH` was supplied — all mutable categories use `Direct`.
     std::array<Entry, CAT_COUNT> m_categories {}; ///< Per-category state.

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -206,7 +206,7 @@ private:
     /// Uses `m_userDataDir`, `m_readOnlyIde`, `m_explicitConfig` so callers
     /// (ctor + `load()` for sub-categories + `reloadConfig` / `setCategoryPath`)
     /// share the same rules.
-    [[nodiscard]] auto buildStrategy(Category category, wxString basePath) const -> ConfigStrategy;
+    [[nodiscard]] auto buildStrategy(Category category, const wxString& basePath) const -> ConfigStrategy;
 
     /// Per-category bookkeeping: storage policy + parsed trees.
     struct Entry final {

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -6,6 +6,7 @@
 //
 #pragma once
 #include "pch.hpp"
+#include "ConfigStrategy.hpp"
 #include "Theme.hpp"
 #include "Value.hpp"
 #include "Version.hpp"
@@ -97,11 +98,20 @@ public:
     // -----------------------------------------------------------------------
 
     /// Construct and load every category from disk.
-    /// @param appPath    Directory of the running fbide binary.
-    /// @param idePath    Override for the `<binary>/ide` resource directory.
-    /// @param configPath Override for the platform default config file
-    ///                   (resolved relative to `idePath` when not absolute).
-    explicit ConfigManager(const wxString& appPath, const wxString& idePath = "", const wxString& configPath = "");
+    /// @param appPath              Directory of the running fbide binary.
+    /// @param idePath              Override for the `<binary>/ide` resource directory.
+    /// @param configPath           Override for the platform default config file
+    ///                             (resolved relative to `idePath` when not absolute).
+    /// @param userDataDirOverride  Test seam — overrides `wxStandardPaths::Get().GetUserDataDir()`
+    ///                             for overlay routing under READONLY. Empty (default) uses
+    ///                             the real platform user-data directory. Production code
+    ///                             never passes this.
+    explicit ConfigManager(
+        const wxString& appPath,
+        const wxString& idePath = "",
+        const wxString& configPath = "",
+        const wxString& userDataDirOverride = ""
+    );
 
     /// Point a category to a new file and reload it.
     void setCategoryPath(Category category, const wxString& path);
@@ -177,17 +187,19 @@ private:
     /// Load the category file from disk and rebuild its Value tree.
     void load(Category category);
 
-    /// Per-category bookkeeping: which file backs it and its parsed root.
+    /// Per-category bookkeeping: storage policy + parsed trees.
     struct Entry final {
-        Category category; ///< Category identifier.
-        wxString path;     ///< Absolute path to the backing INI file.
-        Value root;        ///< Parsed root `Value` for the category.
+        Category category;       ///< Category identifier.
+        ConfigStrategy strategy; ///< Where the file lives and how saves are routed.
+        Value baseline;          ///< Pristine parse of `strategy.basePath()`. Used to diff against `root` on save.
+        Value root;              ///< Merged tree (baseline + overlay). Same as baseline until overlay merge lands.
     };
     /// Number of categories — one slot per `Category` enum value.
     static constexpr std::size_t CAT_COUNT = 5;
 
     wxString m_appDir;                            ///< App directory (binary location).
     wxString m_ideDir {};                         ///< IDE resources directory.
+    wxString m_userDataDir {};                    ///< User-writable dir for overlays + theme copies (READONLY mode).
     std::array<Entry, CAT_COUNT> m_categories {}; ///< Per-category state.
     Theme m_theme {};                             ///< Active editor theme.
 };

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -85,6 +85,11 @@ public:
     /// override exists. Absolute paths are returned as-is.
     [[nodiscard]] auto themePath(const wxString& relPath) const -> wxString;
 
+    /// Directory theme files are written to. Under READONLY this is
+    /// `<UserDataDir>/themes/`; otherwise `<ideDir>/themes/`. Callers
+    /// are responsible for creating it on demand before saving.
+    [[nodiscard]] auto themesWriteDir() const -> wxString;
+
     /// Platform default config file name.
     [[nodiscard]] static auto getPlatformConfigFileName() -> wxString;
 

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -209,21 +209,21 @@ private:
 
     /// Per-category bookkeeping: storage policy + parsed trees.
     struct Entry final {
-        Category category;       ///< Category identifier.
-        ConfigStrategy strategy; ///< Where the file lives and how saves are routed.
-        Value baseline;          ///< Pristine parse of `strategy.basePath()` — diffed against `root` on save.
-        Value root;              ///< Merged tree (baseline + overlay).
+        Category category { Category::Config }; ///< Category identifier; overwritten on `load()`.
+        ConfigStrategy strategy;                ///< Where the file lives and how saves are routed.
+        Value baseline;                         ///< Pristine parse of `strategy.basePath()` — diffed against `root` on save.
+        Value root;                             ///< Merged tree (baseline + overlay).
     };
     /// Number of categories — one slot per `Category` enum value.
     static constexpr std::size_t CAT_COUNT = 5;
 
-    wxString m_appDir;                            ///< App directory (binary location).
+    wxString m_appDir {};                         ///< App directory (binary location).
     wxString m_ideDir {};                         ///< IDE resources directory.
     wxString m_userDataDir {};                    ///< User-writable dir for overlays + theme copies (READONLY mode).
     bool m_readOnlyIde { false };                 ///< True when `READONLY` sentinel routes overlays to `m_userDataDir`.
     bool m_explicitConfig { false };              ///< True when `--config=PATH` was supplied — all mutable categories use `Direct`.
     std::array<Entry, CAT_COUNT> m_categories {}; ///< Per-category state.
-    Theme m_theme {};                             ///< Active editor theme.
+    Theme m_theme;                                ///< Active editor theme.
 };
 
 } // namespace fbide

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -73,8 +73,17 @@ public:
     /// Get paths of every language file under resources/IDE/v2/locales.
     [[nodiscard]] auto getAllLanguages() const -> std::vector<wxString>;
 
-    /// Get paths of every theme file under resources/IDE/v2/themes.
+    /// Get paths of every theme file under `ide/themes/`. Under READONLY,
+    /// also enumerates `<UserDataDir>/themes/`; user entries shadow
+    /// bundle entries on basename collision. Sorted by basename.
     [[nodiscard]] auto getAllThemes() const -> std::vector<wxString>;
+
+    /// Resolve a theme path (relative or absolute) honouring the
+    /// READONLY two-dir model: when the sentinel is present, a file at
+    /// `<UserDataDir>/<relPath>` takes precedence over the bundle copy.
+    /// Falls back to `absolute()` (ide → app → cwd) when no user
+    /// override exists. Absolute paths are returned as-is.
+    [[nodiscard]] auto themePath(const wxString& relPath) const -> wxString;
 
     /// Platform default config file name.
     [[nodiscard]] static auto getPlatformConfigFileName() -> wxString;

--- a/src/lib/config/ConfigManager.hpp
+++ b/src/lib/config/ConfigManager.hpp
@@ -187,12 +187,18 @@ private:
     /// Load the category file from disk and rebuild its Value tree.
     void load(Category category);
 
+    /// Build the `ConfigStrategy` for `category` given a resolved base path.
+    /// Uses `m_userDataDir`, `m_readOnlyIde`, `m_explicitConfig` so callers
+    /// (ctor + `load()` for sub-categories + `reloadConfig` / `setCategoryPath`)
+    /// share the same rules.
+    [[nodiscard]] auto buildStrategy(Category category, wxString basePath) const -> ConfigStrategy;
+
     /// Per-category bookkeeping: storage policy + parsed trees.
     struct Entry final {
         Category category;       ///< Category identifier.
         ConfigStrategy strategy; ///< Where the file lives and how saves are routed.
-        Value baseline;          ///< Pristine parse of `strategy.basePath()`. Used to diff against `root` on save.
-        Value root;              ///< Merged tree (baseline + overlay). Same as baseline until overlay merge lands.
+        Value baseline;          ///< Pristine parse of `strategy.basePath()` — diffed against `root` on save.
+        Value root;              ///< Merged tree (baseline + overlay).
     };
     /// Number of categories — one slot per `Category` enum value.
     static constexpr std::size_t CAT_COUNT = 5;
@@ -200,6 +206,8 @@ private:
     wxString m_appDir;                            ///< App directory (binary location).
     wxString m_ideDir {};                         ///< IDE resources directory.
     wxString m_userDataDir {};                    ///< User-writable dir for overlays + theme copies (READONLY mode).
+    bool m_readOnlyIde { false };                 ///< True when `READONLY` sentinel routes overlays to `m_userDataDir`.
+    bool m_explicitConfig { false };              ///< True when `--config=PATH` was supplied — all mutable categories use `Direct`.
     std::array<Entry, CAT_COUNT> m_categories {}; ///< Per-category state.
     Theme m_theme {};                             ///< Active editor theme.
 };

--- a/src/lib/config/ConfigStrategy.cpp
+++ b/src/lib/config/ConfigStrategy.cpp
@@ -8,24 +8,23 @@
 using namespace fbide;
 
 auto ConfigStrategy::deriveOverlayPath(
-    const wxString& basePath,
-    const wxString& userDataDir,
+    const std::filesystem::path& basePath,
+    const std::filesystem::path& userDataDir,
     const bool readOnly
-) -> wxString {
-    wxFileName fn(basePath);
-    // `config_macos` → `config_macos.local`, extension stays put. Works
-    // for any extension (`.ini`, legacy `.fbt`, ...) — overlay file ends
-    // up `<stem>.local.<ext>`.
-    fn.SetName(fn.GetName() + ".local");
-    if (readOnly) {
-        fn.SetPath(userDataDir);
-    }
-    return fn.GetFullPath();
+) -> std::filesystem::path {
+    // `config_macos.ini` → `config_macos.local.ini`; extension stays
+    // put. Works for any extension (`.ini`, legacy `.fbt`, ...) — the
+    // overlay file ends up `<stem>.local.<ext>`.
+    const auto parent = readOnly ? userDataDir : basePath.parent_path();
+    auto filename = basePath.stem();
+    filename += ".local";
+    filename += basePath.extension();
+    return parent / filename;
 }
 
 auto ConfigStrategy::select(
-    const wxString& basePath,
-    const wxString& userDataDir,
+    const std::filesystem::path& basePath,
+    const std::filesystem::path& userDataDir,
     const bool readOnly,
     const bool overlayCapable,
     const bool explicitMode

--- a/src/lib/config/ConfigStrategy.cpp
+++ b/src/lib/config/ConfigStrategy.cpp
@@ -1,0 +1,37 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include "ConfigStrategy.hpp"
+using namespace fbide;
+
+auto ConfigStrategy::deriveOverlayPath(
+    const wxString& basePath,
+    const wxString& userDataDir,
+    const bool readOnly
+) -> wxString {
+    wxFileName fn(basePath);
+    // `config_macos` → `config_macos.local`, extension stays put. Works
+    // for any extension (`.ini`, legacy `.fbt`, ...) — overlay file ends
+    // up `<stem>.local.<ext>`.
+    fn.SetName(fn.GetName() + ".local");
+    if (readOnly) {
+        fn.SetPath(userDataDir);
+    }
+    return fn.GetFullPath();
+}
+
+auto ConfigStrategy::select(
+    const wxString& basePath,
+    const wxString& userDataDir,
+    const bool readOnly,
+    const bool overlayCapable,
+    const bool explicitMode
+) -> ConfigStrategy {
+    if (!overlayCapable || explicitMode) {
+        return direct(basePath);
+    }
+    return overlay(basePath, deriveOverlayPath(basePath, userDataDir, readOnly));
+}

--- a/src/lib/config/ConfigStrategy.hpp
+++ b/src/lib/config/ConfigStrategy.hpp
@@ -22,8 +22,10 @@ namespace fbide {
 ///   user has taken explicit ownership of the file and reproducibility
 ///   (e.g. CI / repro runs) trumps upgrade-tracking.
 ///
-/// Value semantics: copyable + movable so `ConfigManager::Entry` can
-/// keep one without ceremony, and runtime mutations (`setCategoryPath`,
+/// Paths are `std::filesystem::path` — symlink-aware, encoding-correct,
+/// and free of the wxFileName quirks the bundle hits in practice. Value
+/// semantics: copyable + movable so `ConfigManager::Entry` can keep one
+/// without ceremony, and runtime mutations (`setCategoryPath`,
 /// `reloadConfig`) can swap a strategy in place.
 class [[nodiscard]] ConfigStrategy final {
 public:
@@ -34,13 +36,13 @@ public:
 
     /// Bundle baseline + writable overlay. Both paths must be absolute
     /// and resolved by the caller — this type does no path resolution.
-    [[nodiscard]] static auto overlay(wxString basePath, wxString overlayPath) -> ConfigStrategy {
+    [[nodiscard]] static auto overlay(std::filesystem::path basePath, std::filesystem::path overlayPath) -> ConfigStrategy {
         return { Mode::Overlay, std::move(basePath), std::move(overlayPath) };
     }
 
     /// Single-file mode — bundle baseline bypassed, saves overwrite the
     /// file in place.
-    [[nodiscard]] static auto direct(wxString path) -> ConfigStrategy {
+    [[nodiscard]] static auto direct(std::filesystem::path path) -> ConfigStrategy {
         return { Mode::Direct, std::move(path), {} };
     }
 
@@ -51,10 +53,10 @@ public:
     /// - `readOnly` true  → overlay lives in `userDataDir`.
     /// - `readOnly` false → overlay lives next to `basePath`.
     [[nodiscard]] static auto deriveOverlayPath(
-        const wxString& basePath,
-        const wxString& userDataDir,
+        const std::filesystem::path& basePath,
+        const std::filesystem::path& userDataDir,
         bool readOnly
-    ) -> wxString;
+    ) -> std::filesystem::path;
 
     /// Top-level strategy rule.
     /// - `overlayCapable=false` (e.g. locale)            → `direct(basePath)`.
@@ -63,23 +65,23 @@ public:
     /// - otherwise (default boot, mutable category)      → `overlay(basePath,
     ///   deriveOverlayPath(basePath, userDataDir, readOnly))`.
     [[nodiscard]] static auto select(
-        const wxString& basePath,
-        const wxString& userDataDir,
+        const std::filesystem::path& basePath,
+        const std::filesystem::path& userDataDir,
         bool readOnly,
         bool overlayCapable,
         bool explicitMode
     ) -> ConfigStrategy;
 
     /// Immutable baseline. Always populated regardless of mode.
-    [[nodiscard]] auto basePath() const noexcept -> const wxString& { return m_basePath; }
+    [[nodiscard]] auto basePath() const noexcept -> const std::filesystem::path& { return m_basePath; }
 
     /// Writable overlay path; empty when the strategy is `Direct`.
-    [[nodiscard]] auto overlayPath() const noexcept -> const wxString& { return m_overlayPath; }
+    [[nodiscard]] auto overlayPath() const noexcept -> const std::filesystem::path& { return m_overlayPath; }
 
     /// Path to write on `save()` — overlay in `Overlay` mode, base in
     /// `Direct` mode. Encodes the save-target rule so `ConfigManager`
     /// can stay mode-agnostic.
-    [[nodiscard]] auto savePath() const noexcept -> const wxString& {
+    [[nodiscard]] auto savePath() const noexcept -> const std::filesystem::path& {
         return m_mode == Mode::Overlay ? m_overlayPath : m_basePath;
     }
 
@@ -88,17 +90,19 @@ public:
     [[nodiscard]] auto usesOverlay() const noexcept -> bool { return m_mode == Mode::Overlay; }
 
 private:
-    enum class Mode : std::uint8_t { Overlay,
-        Direct };
+    enum class Mode : std::uint8_t {
+        Overlay,
+        Direct,
+    };
 
-    ConfigStrategy(const Mode mode, wxString basePath, wxString overlayPath)
+    ConfigStrategy(const Mode mode, std::filesystem::path basePath, std::filesystem::path overlayPath)
     : m_mode(mode)
     , m_basePath(std::move(basePath))
     , m_overlayPath(std::move(overlayPath)) {}
 
     Mode m_mode { Mode::Direct };
-    wxString m_basePath {};
-    wxString m_overlayPath {};
+    std::filesystem::path m_basePath;
+    std::filesystem::path m_overlayPath;
 };
 
 } // namespace fbide

--- a/src/lib/config/ConfigStrategy.hpp
+++ b/src/lib/config/ConfigStrategy.hpp
@@ -1,0 +1,104 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#pragma once
+#include "pch.hpp"
+
+namespace fbide {
+
+/// Per-category storage policy for a `ConfigManager` entry.
+///
+/// Two modes:
+/// - **Overlay** — bundle baseline at `basePath()` plus a writable
+///   `.local.ini` overlay at `overlayPath()`. Loads merge the two; saves
+///   write only divergences from baseline into the overlay (aggressively
+///   pruned). This is the default-boot mode.
+/// - **Direct** — single file at `basePath()`, no overlay. Loads and
+///   saves both target that file. Used when the user passed
+///   `--config=PATH` or invoked `reloadConfig(path)` at runtime — the
+///   user has taken explicit ownership of the file and reproducibility
+///   (e.g. CI / repro runs) trumps upgrade-tracking.
+///
+/// Value semantics: copyable + movable so `ConfigManager::Entry` can
+/// keep one without ceremony, and runtime mutations (`setCategoryPath`,
+/// `reloadConfig`) can swap a strategy in place.
+class [[nodiscard]] ConfigStrategy final {
+public:
+    /// Default-constructed strategy — `Direct` mode with empty paths.
+    /// Used as a placeholder for category slots that haven't been
+    /// loaded yet; `ConfigManager` overwrites it during `load()`.
+    ConfigStrategy() = default;
+
+    /// Bundle baseline + writable overlay. Both paths must be absolute
+    /// and resolved by the caller — this type does no path resolution.
+    [[nodiscard]] static auto overlay(wxString basePath, wxString overlayPath) -> ConfigStrategy {
+        return { Mode::Overlay, std::move(basePath), std::move(overlayPath) };
+    }
+
+    /// Single-file mode — bundle baseline bypassed, saves overwrite the
+    /// file in place.
+    [[nodiscard]] static auto direct(wxString path) -> ConfigStrategy {
+        return { Mode::Direct, std::move(path), {} };
+    }
+
+    /// Compute the `<base>.local.ini` overlay path for a given base file.
+    /// Inserts `.local` before the extension so theme `.fbt` overlays
+    /// would round-trip identically (themes don't actually use overlays
+    /// today, but the rule generalises cleanly).
+    /// - `readOnly` true  → overlay lives in `userDataDir`.
+    /// - `readOnly` false → overlay lives next to `basePath`.
+    [[nodiscard]] static auto deriveOverlayPath(
+        const wxString& basePath,
+        const wxString& userDataDir,
+        bool readOnly
+    ) -> wxString;
+
+    /// Top-level strategy rule.
+    /// - `overlayCapable=false` (e.g. locale)            → `direct(basePath)`.
+    /// - `explicitMode=true` (`--config=PATH` or runtime
+    ///   `reloadConfig`)                                  → `direct(basePath)`.
+    /// - otherwise (default boot, mutable category)      → `overlay(basePath,
+    ///   deriveOverlayPath(basePath, userDataDir, readOnly))`.
+    [[nodiscard]] static auto select(
+        const wxString& basePath,
+        const wxString& userDataDir,
+        bool readOnly,
+        bool overlayCapable,
+        bool explicitMode
+    ) -> ConfigStrategy;
+
+    /// Immutable baseline. Always populated regardless of mode.
+    [[nodiscard]] auto basePath() const noexcept -> const wxString& { return m_basePath; }
+
+    /// Writable overlay path; empty when the strategy is `Direct`.
+    [[nodiscard]] auto overlayPath() const noexcept -> const wxString& { return m_overlayPath; }
+
+    /// Path to write on `save()` — overlay in `Overlay` mode, base in
+    /// `Direct` mode. Encodes the save-target rule so `ConfigManager`
+    /// can stay mode-agnostic.
+    [[nodiscard]] auto savePath() const noexcept -> const wxString& {
+        return m_mode == Mode::Overlay ? m_overlayPath : m_basePath;
+    }
+
+    /// True when `Overlay` — caller must run merge on load and
+    /// diff-against-baseline + prune on save.
+    [[nodiscard]] auto usesOverlay() const noexcept -> bool { return m_mode == Mode::Overlay; }
+
+private:
+    enum class Mode : std::uint8_t { Overlay,
+        Direct };
+
+    ConfigStrategy(const Mode mode, wxString basePath, wxString overlayPath)
+    : m_mode(mode)
+    , m_basePath(std::move(basePath))
+    , m_overlayPath(std::move(overlayPath)) {}
+
+    Mode m_mode { Mode::Direct };
+    wxString m_basePath {};
+    wxString m_overlayPath {};
+};
+
+} // namespace fbide

--- a/src/lib/config/Value.cpp
+++ b/src/lib/config/Value.cpp
@@ -294,3 +294,30 @@ auto Value::operator=(const char* v) -> Value& {
     m_data = wxString { v };
     return *this;
 }
+
+// -------------------------------------------------------------------------
+// Overlay merge
+// -------------------------------------------------------------------------
+void Value::mergeFrom(const Value& other) {
+    // Invalid overlay = no-op. Lets callers pass a default-constructed
+    // Value when the overlay file is absent without checking first.
+    if (!other) {
+        return;
+    }
+
+    // Overlay leaf — replace this whole subtree. Captures both the
+    // same-leaf case and the type-mismatch case (overlay leaf where
+    // we're a group). `operator=(const wxString&)` resets m_data to a
+    // leaf, dropping any prior Table.
+    if (!other.isTable()) {
+        *this = other.as<wxString>().value_or(wxString {});
+        return;
+    }
+
+    // Overlay group — recurse per child. `operator[]` converts this node
+    // to a Table if it isn't already (type-mismatch: overlay group where
+    // we're a leaf), and creates missing children on demand.
+    for (const auto& [key, child] : other.entries()) {
+        (*this)[key].mergeFrom(*child);
+    }
+}

--- a/src/lib/config/Value.cpp
+++ b/src/lib/config/Value.cpp
@@ -321,3 +321,41 @@ void Value::mergeFrom(const Value& other) {
         (*this)[key].mergeFrom(*child);
     }
 }
+
+auto Value::diffAgainst(const Value& baseline) const -> Value {
+    Value out;
+
+    // Leaf (or invalid) at this node — emit only if our leaf actually
+    // differs from baseline's leaf at the same point. Type mismatch
+    // (baseline is a group, or baseline is absent) counts as divergence
+    // and forces the leaf out.
+    if (!isTable()) {
+        if (!*this) {
+            return out;
+        }
+        const auto mergedLeaf = as<wxString>().value_or(wxString {});
+        if (baseline.isTable() || !baseline) {
+            out = mergedLeaf;
+            return out;
+        }
+        const auto baselineLeaf = baseline.as<wxString>().value_or(wxString {});
+        if (mergedLeaf != baselineLeaf) {
+            out = mergedLeaf;
+        }
+        return out;
+    }
+
+    // Group — recurse per child. Children present only in baseline are
+    // never visited, so deletion is intentionally unexpressible by diff.
+    // Children whose own diff is empty are skipped, so parent groups are
+    // synthesised on `out` only when they contain a divergence.
+    for (const auto& [key, child] : entries()) {
+        Value childDiff = child->diffAgainst(baseline.at(key));
+        if (childDiff) {
+            // operator[] creates the child slot under out; move-assign
+            // embeds the recursive diff via the defaulted Value&& operator.
+            out[key] = std::move(childDiff);
+        }
+    }
+    return out;
+}

--- a/src/lib/config/Value.hpp
+++ b/src/lib/config/Value.hpp
@@ -129,6 +129,18 @@ public:
     [[nodiscard]] auto entries() const -> const Table&;
 
     // -------------------------------------------------------------------
+    // Overlay merge
+    // -------------------------------------------------------------------
+
+    /// Recursively overlay `other` on top of this tree. Leaves in `other`
+    /// replace leaves at the same path; groups recurse; keys present only
+    /// in this tree are preserved. Empty-string leaves still override
+    /// (key-presence wins regardless of value). On a type mismatch
+    /// (overlay leaf where this is a group, or vice versa) the overlay
+    /// always wins — same rule as leaves.
+    void mergeFrom(const Value& other);
+
+    // -------------------------------------------------------------------
     // Writes — replace this node's contents with a leaf
     // -------------------------------------------------------------------
     /// Assign a `bool` leaf.

--- a/src/lib/config/Value.hpp
+++ b/src/lib/config/Value.hpp
@@ -140,6 +140,15 @@ public:
     /// always wins — same rule as leaves.
     void mergeFrom(const Value& other);
 
+    /// Return the subset of this tree whose leaves differ from `baseline`
+    /// at the same path (or are absent from baseline). Result has only the
+    /// divergent leaves plus the parent groups required to reach them.
+    /// Inverse of `mergeFrom`: `baseline.mergeFrom(merged.diffAgainst(baseline))`
+    /// reconstructs `merged`. Deletion semantics not expressed — keys
+    /// present in baseline but absent from this tree are NOT in the diff
+    /// (the user expresses deletion by editing the overlay file directly).
+    [[nodiscard]] auto diffAgainst(const Value& baseline) const -> Value;
+
     // -------------------------------------------------------------------
     // Writes — replace this node's contents with a leaf
     // -------------------------------------------------------------------

--- a/src/lib/settings/panels/ThemePage.cpp
+++ b/src/lib/settings/panels/ThemePage.cpp
@@ -314,7 +314,16 @@ void ThemePage::onSaveTheme(wxCommandEvent&) {
         updateTitle();
     }
 
-    m_theme.save();
+    // Route saves through `themesWriteDir()` — under READONLY this is
+    // `<UserDataDir>/themes/`, so edits to a bundled theme land in the
+    // user copy (which then shadows the bundle via the two-dir merge
+    // in `getAllThemes`). Same-name file in portable mode is a no-op
+    // redirect.
+    auto& cm = getContext().getConfigManager();
+    const wxString writeDir = cm.themesWriteDir();
+    wxFileName::Mkdir(writeDir, 0755, wxPATH_MKDIR_FULL);
+    const wxString target = writeDir + wxFILE_SEP_PATH + wxFileName(m_theme.getPath()).GetFullName();
+    m_theme.save(target);
 
     const auto currentThemeName = getContext().getTheme().getPath();
     if (m_activeTheme == currentThemeName) {
@@ -339,7 +348,8 @@ void ThemePage::saveNewTheme(const bool setActive) {
         return;
     }
 
-    const wxFileName path(getContext().getConfigManager().getIdeDir() / "themes" / name + ".ini");
+    const wxString writeDir = getContext().getConfigManager().themesWriteDir();
+    const wxFileName path(writeDir / name + ".ini");
     if (not path.IsOk()) {
         wxMessageBox(wxString::Format(tr("invalidFilename"), path.GetFullPath()));
         return;
@@ -350,6 +360,7 @@ void ThemePage::saveNewTheme(const bool setActive) {
         return;
     }
 
+    wxFileName::Mkdir(writeDir, 0755, wxPATH_MKDIR_FULL);
     m_theme.save(path.GetAbsolutePath());
     m_themeChoice->Append(name);
     m_themeChoice->SetStringSelection(name);

--- a/src/lib/settings/panels/ThemePage.cpp
+++ b/src/lib/settings/panels/ThemePage.cpp
@@ -310,20 +310,20 @@ void ThemePage::onSaveTheme(wxCommandEvent&) {
     saveCategory();
 
     if (isUnsavedNewTheme()) {
+        // saveNewTheme writes the theme at `themesWriteDir() / name`
+        // already; no second save needed.
         saveNewTheme(false);
         updateTitle();
+    } else {
+        // Route existing-theme saves through `themesWriteDir()` —
+        // under READONLY this is `<UserDataDir>/themes/`, so edits to
+        // a bundled theme land in the user copy (which then shadows
+        // the bundle via the two-dir merge in `getAllThemes`). Same-
+        // name file in portable mode is a no-op redirect.
+        auto& cm = getContext().getConfigManager();
+        const wxString target = cm.themesWriteDir() / wxFileName(m_theme.getPath()).GetFullName();
+        m_theme.save(target);
     }
-
-    // Route saves through `themesWriteDir()` — under READONLY this is
-    // `<UserDataDir>/themes/`, so edits to a bundled theme land in the
-    // user copy (which then shadows the bundle via the two-dir merge
-    // in `getAllThemes`). Same-name file in portable mode is a no-op
-    // redirect.
-    auto& cm = getContext().getConfigManager();
-    const wxString writeDir = cm.themesWriteDir();
-    wxFileName::Mkdir(writeDir, 0755, wxPATH_MKDIR_FULL);
-    const wxString target = writeDir + wxFILE_SEP_PATH + wxFileName(m_theme.getPath()).GetFullName();
-    m_theme.save(target);
 
     const auto currentThemeName = getContext().getTheme().getPath();
     if (m_activeTheme == currentThemeName) {
@@ -348,8 +348,7 @@ void ThemePage::saveNewTheme(const bool setActive) {
         return;
     }
 
-    const wxString writeDir = getContext().getConfigManager().themesWriteDir();
-    const wxFileName path(writeDir / name + ".ini");
+    const wxFileName path(getContext().getConfigManager().themesWriteDir() / name + ".ini");
     if (not path.IsOk()) {
         wxMessageBox(wxString::Format(tr("invalidFilename"), path.GetFullPath()));
         return;
@@ -360,7 +359,6 @@ void ThemePage::saveNewTheme(const bool setActive) {
         return;
     }
 
-    wxFileName::Mkdir(writeDir, 0755, wxPATH_MKDIR_FULL);
     m_theme.save(path.GetAbsolutePath());
     m_themeChoice->Append(name);
     m_themeChoice->SetStringSelection(name);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(tests
     unit/SymbolTableTests.cpp
     unit/TextEncodingTests.cpp
     unit/ThemeTests.cpp
+    unit/ValueDiffTests.cpp
     unit/ValueMergeTests.cpp
     unit/VersionTests.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(tests
     unit/BasicTests.cpp
     unit/CompileCommandTests.cpp
     unit/ConfigManagerTests.cpp
+    unit/ConfigStrategyTests.cpp
     unit/DocumentIOTests.cpp
     unit/DocumentPathTests.cpp
     unit/EncodingDetectorTests.cpp
@@ -30,6 +31,7 @@ add_executable(tests
     unit/SymbolTableTests.cpp
     unit/TextEncodingTests.cpp
     unit/ThemeTests.cpp
+    unit/ValueMergeTests.cpp
     unit/VersionTests.cpp
 )
 

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -370,6 +370,28 @@ TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
     EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
 }
 
+TEST_F(ConfigManagerTests, ThemesWriteDirRoutesByReadOnly) {
+    // Portable → bundle themes dir; READONLY → user themes dir. This is
+    // the rule ThemePage::onSaveTheme uses to redirect save targets so
+    // edits to a bundle-shipped theme land in the user-writable copy.
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+
+    // Portable
+    {
+        ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+        EXPECT_EQ(cm.themesWriteDir(), tmp.path() + "/ide/themes");
+    }
+
+    // READONLY routes to user dir
+    tmp.write("ide/READONLY", "");
+    {
+        ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+        EXPECT_EQ(cm.themesWriteDir(), tmp.path() + "/userdata/themes");
+    }
+}
+
 TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
     // Default-boot start with overlay-mode keywords. After
     // `reloadConfig(PATH)` flips to explicit mode, mutating and saving

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -62,8 +62,7 @@ TEST_F(ConfigManagerTests, MissingKeywordsLoadsEmpty) {
     TempDir tmp;
     tmp.write("config.ini",
         "version=0.5.0\n"
-        "keywords=does_not_exist.ini\n"
-    );
+        "keywords=does_not_exist.ini\n");
 
     ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
     auto& kw = cm.keywords();
@@ -76,8 +75,7 @@ TEST_F(ConfigManagerTests, MissingShortcutsLoadsEmpty) {
     TempDir tmp;
     tmp.write("config.ini",
         "version=0.5.0\n"
-        "shortcuts=does_not_exist.ini\n"
-    );
+        "shortcuts=does_not_exist.ini\n");
 
     ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
     auto& sc = cm.shortcuts();
@@ -99,8 +97,7 @@ TEST_F(ConfigManagerTests, MissingThemeFileTriggersDefaults) {
     TempDir tmp;
     tmp.write("config.ini",
         "version=0.5.0\n"
-        "theme=themes/does_not_exist.ini\n"
-    );
+        "theme=themes/does_not_exist.ini\n");
 
     ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
     const auto& theme = cm.getTheme();
@@ -117,4 +114,182 @@ TEST_F(ConfigManagerTests, MissingThemeEntryTriggersDefaults) {
     const auto& theme = cm.getTheme();
     EXPECT_EQ(theme.get(ThemeCategory::Default).colors.foreground, *wxBLACK);
     EXPECT_EQ(theme.get(ThemeCategory::Default).colors.background, *wxWHITE);
+}
+
+// ---------------------------------------------------------------------------
+// Layered config — bundle base + .local.ini overlay
+//
+// These tests exercise the default-boot path (empty `configPath` → Overlay
+// strategy). They lay out a minimal bundle under <tmp>/ide/ and drive
+// READONLY routing via the `userDataDirOverride` ctor seam so nothing
+// touches the real platform user-data directory.
+// ---------------------------------------------------------------------------
+
+namespace {
+/// Compute the `<base>.local.ini` filename for the running platform's
+/// config — same logic as `ConfigStrategy::deriveOverlayPath` but just
+/// the basename, since these tests pick the path themselves.
+auto overlayBasename(const wxString& configBasename) -> wxString {
+    wxFileName fn(configBasename);
+    fn.SetName(fn.GetName() + ".local");
+    return fn.GetFullName();
+}
+} // namespace
+
+TEST_F(ConfigManagerTests, DefaultBootPortableNoOverlayLoadsBundleAsIs) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n"
+        "theme=dark\n");
+
+    // No overlay file present — root must reflect bundle exactly.
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "4");
+    EXPECT_EQ(cm.config().get_or("editor.theme", wxString { "<missing>" }), "dark");
+}
+
+TEST_F(ConfigManagerTests, DefaultBootOverlayMergesIntoConfigRoot) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n"
+        "theme=dark\n");
+    tmp.write("ide/" + overlayBasename(cfgName),
+        "[editor]\n"
+        "tabSize=8\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    // Overlay wins where it diverges, bundle survives where it doesn't.
+    EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "8");
+    EXPECT_EQ(cm.config().get_or("editor.theme", wxString { "<missing>" }), "dark");
+}
+
+TEST_F(ConfigManagerTests, SaveMatchingBaselineProducesNoOverlayFile) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    // Mutate then revert — diff against baseline is empty.
+    cm.config()["editor"]["tabSize"] = "8";
+    cm.config()["editor"]["tabSize"] = "4";
+    cm.save(ConfigManager::Category::Config);
+
+    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
+    EXPECT_FALSE(wxFileExists(overlayPath));
+}
+
+TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n"
+        "theme=dark\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    cm.config()["editor"]["tabSize"] = "8";
+    cm.save(ConfigManager::Category::Config);
+
+    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
+    ASSERT_TRUE(wxFileExists(overlayPath));
+
+    // Parse the produced overlay and confirm it carries only the divergence.
+    wxFFileInputStream in(overlayPath);
+    wxFileConfig produced(in, wxConvUTF8);
+    wxString value;
+    EXPECT_TRUE(produced.Read("editor/tabSize", &value));
+    EXPECT_EQ(value, "8");
+    EXPECT_FALSE(produced.Read("editor/theme", &value));
+}
+
+TEST_F(ConfigManagerTests, SaveResetToBaselineDeletesExistingOverlay) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n");
+    // Pre-existing overlay from a previous run that we now revert.
+    tmp.write("ide/" + overlayBasename(cfgName),
+        "[editor]\n"
+        "tabSize=8\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString {}), "8");
+
+    cm.config()["editor"]["tabSize"] = "4";
+    cm.save(ConfigManager::Category::Config);
+
+    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
+    EXPECT_FALSE(wxFileExists(overlayPath));
+}
+
+TEST_F(ConfigManagerTests, ReadOnlyRoutesOverlayToUserDataDir) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n");
+    tmp.write("ide/READONLY", "");
+    // userDataDir must exist before we try to write into it.
+    wxFileName::Mkdir(tmp.path() + "/userdata", 0755, wxPATH_MKDIR_FULL);
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    cm.config()["editor"]["tabSize"] = "8";
+    cm.save(ConfigManager::Category::Config);
+
+    const wxString bundleOverlay = tmp.path() + "/ide/" + overlayBasename(cfgName);
+    const wxString userOverlay = tmp.path() + "/userdata/" + overlayBasename(cfgName);
+    EXPECT_FALSE(wxFileExists(bundleOverlay));
+    EXPECT_TRUE(wxFileExists(userOverlay));
+}
+
+TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
+    // Round-trip: write an overlay into the user dir, construct
+    // ConfigManager pointing at the same dir, confirm the overlay is
+    // picked up during load (not the absent bundle-adjacent one).
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName,
+        "[editor]\n"
+        "tabSize=4\n");
+    tmp.write("ide/READONLY", "");
+    tmp.write("userdata/" + overlayBasename(cfgName),
+        "[editor]\n"
+        "tabSize=12\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "12");
+}
+
+TEST_F(ConfigManagerTests, ExplicitConfigPathBypassesOverlay) {
+    // `--config=PATH` semantics: even with READONLY sentinel and an
+    // overlay file alongside, the explicit path is treated as a single
+    // self-contained config. Saves go back to PATH directly.
+    TempDir tmp;
+    tmp.write("explicit.ini",
+        "[editor]\n"
+        "tabSize=4\n");
+    tmp.write("explicit.local.ini",
+        "[editor]\n"
+        "tabSize=999\n");
+
+    ConfigManager cm(tmp.path(), tmp.path(), "explicit.ini");
+    // Overlay must be ignored — root reflects the explicit file only.
+    EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString {}), "4");
+
+    cm.config()["editor"]["tabSize"] = "16";
+    cm.save(ConfigManager::Category::Config);
+
+    // Save must overwrite explicit.ini, not produce any new overlay.
+    wxFFileInputStream in(tmp.path() + "/explicit.ini");
+    wxFileConfig roundTrip(in, wxConvUTF8);
+    wxString value;
+    EXPECT_TRUE(roundTrip.Read("editor/tabSize", &value));
+    EXPECT_EQ(value, "16");
 }

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -370,6 +370,35 @@ TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
     EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
 }
 
+TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
+    // Locale is bundle-only — no code path should ever ask the IDE to
+    // write it. `save(Locale)` must refuse rather than truncate the
+    // shipped locale file (which would happen under portable mode where
+    // the bundle dir is writable). Asserts both branches: in-memory
+    // mutation does not reach disk, and the on-disk file is byte-for-
+    // byte unchanged.
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "locale=locales/en.ini\n");
+    tmp.write("ide/locales/en.ini",
+        "[strings]\n"
+        "greeting=Hello\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ASSERT_EQ(cm.locale().get_or("strings.greeting", wxString {}), "Hello");
+
+    // Mutate in-memory then attempt to persist. For any other category
+    // this would round-trip to disk; for Locale we expect a refusal.
+    cm.locale()["strings"]["greeting"] = "Bonjour";
+    cm.save(ConfigManager::Category::Locale);
+
+    wxFFileInputStream roundTripStream(tmp.path() + "/ide/locales/en.ini");
+    wxFileConfig roundTrip(roundTripStream, wxConvUTF8);
+    wxString value;
+    ASSERT_TRUE(roundTrip.Read("strings/greeting", &value));
+    EXPECT_EQ(value, "Hello");
+}
+
 TEST_F(ConfigManagerTests, RelativeOfUserDataPathStripsUserDataPrefix) {
     // Regression: under READONLY, `themesWriteDir()` returns
     // `<UserDataDir>/themes/`, so a theme saved there yields an absolute

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -24,7 +24,7 @@ public:
     TempDir() {
         const auto base = wxFileName::CreateTempFileName("fbide_cfg_test");
         wxRemoveFile(base);
-        wxFileName::Mkdir(base, 0755, wxPATH_MKDIR_FULL);
+        wxFileName::Mkdir(base, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         m_path = base;
     }
     ~TempDir() {
@@ -33,16 +33,16 @@ public:
         }
     }
     TempDir(const TempDir&) = delete;
-    TempDir& operator=(const TempDir&) = delete;
+    auto operator=(const TempDir&) -> TempDir& = delete;
     TempDir(TempDir&&) = delete;
-    TempDir& operator=(TempDir&&) = delete;
+    auto operator=(TempDir&&) -> TempDir& = delete;
 
     [[nodiscard]] auto path() const -> const wxString& { return m_path; }
 
     void write(const wxString& relPath, const wxString& contents) const {
         const wxString full = m_path + "/" + relPath;
-        wxFileName fn(full);
-        wxFileName::Mkdir(fn.GetPath(), 0755, wxPATH_MKDIR_FULL);
+        const wxFileName fn(full);
+        wxFileName::Mkdir(fn.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         wxFFile out(full, "w");
         out.Write(contents);
     }
@@ -73,6 +73,9 @@ auto overlayBasename() -> wxString {
 }
 } // namespace
 
+// gtest fixtures are referenced by TEST_F macro expansion and
+// idiomatically stay at file scope.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 class ConfigManagerTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------
@@ -91,12 +94,12 @@ TEST_F(ConfigManagerTests, MissingNonFatalCategoriesLoadEmpty) {
         const char* configLine;
         const char* lookupKey;
     };
-    const Case cases[] = {
-        { ConfigManager::Category::Keywords, "keywords=does_not_exist.ini\n", "groups.Keywords" },
-        { ConfigManager::Category::Shortcuts, "shortcuts=does_not_exist.ini\n", "file.open" },
-    };
+    const std::array<Case, 2> cases = { {
+        { .cat = ConfigManager::Category::Keywords, .configLine = "keywords=does_not_exist.ini\n", .lookupKey = "groups.Keywords" },
+        { .cat = ConfigManager::Category::Shortcuts, .configLine = "shortcuts=does_not_exist.ini\n", .lookupKey = "file.open" },
+    } };
     for (const auto& tc : cases) {
-        TempDir tmp;
+        const TempDir tmp;
         tmp.write("config.ini", wxString::Format("version=0.5.0\n%s", tc.configLine));
 
         ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
@@ -114,7 +117,7 @@ TEST_F(ConfigManagerTests, MissingNonFatalCategoriesLoadEmpty) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ConfigManagerTests, MissingThemeFileTriggersDefaults) {
-    TempDir tmp;
+    const TempDir tmp;
     tmp.write("config.ini",
         "version=0.5.0\n"
         "theme=themes/does_not_exist.ini\n");
@@ -126,7 +129,7 @@ TEST_F(ConfigManagerTests, MissingThemeFileTriggersDefaults) {
 }
 
 TEST_F(ConfigManagerTests, MissingThemeEntryTriggersDefaults) {
-    TempDir tmp;
+    const TempDir tmp;
     // No `theme=` key at all — fallback kicks in just the same.
     tmp.write("config.ini", "version=0.5.0\n");
 
@@ -146,7 +149,7 @@ TEST_F(ConfigManagerTests, MissingThemeEntryTriggersDefaults) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ConfigManagerTests, DefaultBootPortableNoOverlayLoadsBundleAsIs) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
@@ -159,7 +162,7 @@ TEST_F(ConfigManagerTests, DefaultBootPortableNoOverlayLoadsBundleAsIs) {
 }
 
 TEST_F(ConfigManagerTests, DefaultBootOverlayMergesIntoConfigRoot) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
@@ -175,7 +178,7 @@ TEST_F(ConfigManagerTests, DefaultBootOverlayMergesIntoConfigRoot) {
 }
 
 TEST_F(ConfigManagerTests, SaveMatchingBaselineProducesNoOverlayFile) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n");
@@ -190,7 +193,7 @@ TEST_F(ConfigManagerTests, SaveMatchingBaselineProducesNoOverlayFile) {
 }
 
 TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
@@ -205,7 +208,7 @@ TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
 
     // Parse the produced overlay and confirm it carries only the divergence.
     wxFFileInputStream in(overlayPath);
-    wxFileConfig produced(in, wxConvUTF8);
+    const wxFileConfig produced(in, wxConvUTF8);
     wxString value;
     EXPECT_TRUE(produced.Read("editor/tabSize", &value));
     EXPECT_EQ(value, "8");
@@ -213,7 +216,7 @@ TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
 }
 
 TEST_F(ConfigManagerTests, SaveResetToBaselineDeletesExistingOverlay) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n");
@@ -232,7 +235,7 @@ TEST_F(ConfigManagerTests, SaveResetToBaselineDeletesExistingOverlay) {
 }
 
 TEST_F(ConfigManagerTests, ReadOnlyRoutesOverlayToUserDataDir) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n",
@@ -250,7 +253,7 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
     // Round-trip: write an overlay into the user dir, construct
     // ConfigManager pointing at the same dir, confirm the overlay is
     // picked up during load (not the absent bundle-adjacent one).
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n",
@@ -268,58 +271,58 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ConfigManagerTests, GetAllThemesPortableEnumeratesBundleOnly) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("ide/themes/light.ini", "[Default]\n");
     // userdata exists but no READONLY — its themes/ must not contribute.
     tmp.write("userdata/themes/ignored.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 2);
-    EXPECT_EQ(wxFileName(themes[0]).GetFullName(), "dark.ini");
-    EXPECT_EQ(wxFileName(themes[1]).GetFullName(), "light.ini");
+    EXPECT_EQ(wxFileName(themes.at(0)).GetFullName(), "dark.ini");
+    EXPECT_EQ(wxFileName(themes.at(1)).GetFullName(), "light.ini");
 }
 
 TEST_F(ConfigManagerTests, GetAllThemesReadOnlyMergesBundleAndUserDirs) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("ide/themes/light.ini", "[Default]\n");
     tmp.write("userdata/themes/solarized.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 3);
     // Sorted by basename across both dirs.
-    EXPECT_EQ(wxFileName(themes[0]).GetFullName(), "dark.ini");
-    EXPECT_EQ(wxFileName(themes[1]).GetFullName(), "light.ini");
-    EXPECT_EQ(wxFileName(themes[2]).GetFullName(), "solarized.ini");
+    EXPECT_EQ(wxFileName(themes.at(0)).GetFullName(), "dark.ini");
+    EXPECT_EQ(wxFileName(themes.at(1)).GetFullName(), "light.ini");
+    EXPECT_EQ(wxFileName(themes.at(2)).GetFullName(), "solarized.ini");
 }
 
 TEST_F(ConfigManagerTests, GetAllThemesUserDirWinsOnBasenameCollision) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 1);
-    EXPECT_EQ(wxFileName(themes[0]).GetPath(), tmp.path() + "/userdata/themes");
+    EXPECT_EQ(wxFileName(themes.at(0)).GetPath(), tmp.path() + "/userdata/themes");
 }
 
 TEST_F(ConfigManagerTests, ThemePathReadOnlyPrefersUserOverride) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     EXPECT_EQ(
         wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
@@ -328,11 +331,11 @@ TEST_F(ConfigManagerTests, ThemePathReadOnlyPrefersUserOverride) {
 }
 
 TEST_F(ConfigManagerTests, ThemePathReadOnlyFallsBackToBundleWhenUserMissing) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     EXPECT_EQ(
         wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
@@ -341,13 +344,13 @@ TEST_F(ConfigManagerTests, ThemePathReadOnlyFallsBackToBundleWhenUserMissing) {
 }
 
 TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
     // No READONLY sentinel → user dir is ignored even though it exists.
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     EXPECT_EQ(
         wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
@@ -362,7 +365,7 @@ TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
     // the bundle dir is writable). Asserts both branches: in-memory
     // mutation does not reach disk, and the on-disk file is byte-for-
     // byte unchanged.
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "locale=locales/en.ini\n");
     tmp.write("ide/locales/en.ini",
         "[strings]\n"
@@ -377,7 +380,7 @@ TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
     cm.save(ConfigManager::Category::Locale);
 
     wxFFileInputStream roundTripStream(ideDir + "/locales/en.ini");
-    wxFileConfig roundTrip(roundTripStream, wxConvUTF8);
+    const wxFileConfig roundTrip(roundTripStream, wxConvUTF8);
     wxString value;
     ASSERT_TRUE(roundTrip.Read("strings/greeting", &value));
     EXPECT_EQ(value, "Hello");
@@ -390,11 +393,11 @@ TEST_F(ConfigManagerTests, RelativeOfUserDataPathStripsUserDataPrefix) {
     // way it strips `m_ideDir` — otherwise `config["theme"]` ends up
     // storing the full absolute path and leaks the user's home dir
     // into the overlay file.
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("userdata/themes/modern-dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+    const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     EXPECT_EQ(
         cm.relative(tmp.path() + "/userdata/themes/modern-dark.ini"),
@@ -406,19 +409,19 @@ TEST_F(ConfigManagerTests, ThemesWriteDirRoutesByReadOnly) {
     // Portable → bundle themes dir; READONLY → user themes dir. This is
     // the rule ThemePage::onSaveTheme uses to redirect save targets so
     // edits to a bundle-shipped theme land in the user-writable copy.
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp);
 
     // Portable
     {
-        ConfigManager cm(tmp.path(), ideDir, "");
+        const ConfigManager cm(tmp.path(), ideDir, "");
         EXPECT_EQ(cm.themesWriteDir(), ideDir + "/themes");
     }
 
     // READONLY routes to user dir
     tmp.write("ide/READONLY", "");
     {
-        ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
+        const ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
         EXPECT_EQ(cm.themesWriteDir(), tmp.path() + "/userdata/themes");
     }
 }
@@ -429,7 +432,7 @@ TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
     // keywords must hit the base file directly — no `.local.ini` is
     // produced, because the sub-category strategy was rebuilt under
     // the new mode.
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "keywords=keywords.ini\n");
     tmp.write("ide/keywords.ini",
         "[functions]\n"
@@ -455,7 +458,7 @@ TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
     EXPECT_FALSE(wxFileExists(tmp.path() + "/alt_keywords.local.ini"));
 
     wxFFileInputStream in(tmp.path() + "/alt_keywords.ini");
-    wxFileConfig produced(in, wxConvUTF8);
+    const wxFileConfig produced(in, wxConvUTF8);
     wxString value;
     EXPECT_TRUE(produced.Read("functions/Bar", &value));
     EXPECT_EQ(value, "1");
@@ -465,7 +468,7 @@ TEST_F(ConfigManagerTests, SetCategoryPathInheritsBootModeStrategy) {
     // Default-boot rotation. `setCategoryPath` flows through `load()`
     // which calls `buildStrategy()` under the current mode (Overlay),
     // so the new sub-category gets an overlay path alongside its base.
-    TempDir tmp;
+    const TempDir tmp;
     const auto ideDir = seedBundle(tmp, "keywords=keywords.ini\n");
     tmp.write("ide/keywords.ini",
         "[functions]\n"
@@ -491,7 +494,7 @@ TEST_F(ConfigManagerTests, ExplicitConfigPathBypassesOverlay) {
     // `--config=PATH` semantics: even with READONLY sentinel and an
     // overlay file alongside, the explicit path is treated as a single
     // self-contained config. Saves go back to PATH directly.
-    TempDir tmp;
+    const TempDir tmp;
     tmp.write("explicit.ini",
         "[editor]\n"
         "tabSize=4\n");
@@ -508,7 +511,7 @@ TEST_F(ConfigManagerTests, ExplicitConfigPathBypassesOverlay) {
 
     // Save must overwrite explicit.ini, not produce any new overlay.
     wxFFileInputStream in(tmp.path() + "/explicit.ini");
-    wxFileConfig roundTrip(in, wxConvUTF8);
+    const wxFileConfig roundTrip(in, wxConvUTF8);
     wxString value;
     EXPECT_TRUE(roundTrip.Read("editor/tabSize", &value));
     EXPECT_EQ(value, "16");

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -267,6 +267,109 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "12");
 }
 
+// ---------------------------------------------------------------------------
+// Theme two-dir enumeration + path resolution (READONLY only)
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigManagerTests, GetAllThemesPortableEnumeratesBundleOnly) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    tmp.write("ide/themes/light.ini", "[Default]\n");
+    // userdata exists but no READONLY — its themes/ must not contribute.
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/ignored.ini", "[Default]\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto themes = cm.getAllThemes();
+    ASSERT_EQ(themes.size(), 2);
+    EXPECT_EQ(wxFileName(themes[0]).GetFullName(), "dark.ini");
+    EXPECT_EQ(wxFileName(themes[1]).GetFullName(), "light.ini");
+}
+
+TEST_F(ConfigManagerTests, GetAllThemesReadOnlyMergesBundleAndUserDirs) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/READONLY", "");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    tmp.write("ide/themes/light.ini", "[Default]\n");
+
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/solarized.ini", "[Default]\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto themes = cm.getAllThemes();
+    ASSERT_EQ(themes.size(), 3);
+    // Sorted by basename across both dirs.
+    EXPECT_EQ(wxFileName(themes[0]).GetFullName(), "dark.ini");
+    EXPECT_EQ(wxFileName(themes[1]).GetFullName(), "light.ini");
+    EXPECT_EQ(wxFileName(themes[2]).GetFullName(), "solarized.ini");
+}
+
+TEST_F(ConfigManagerTests, GetAllThemesUserDirWinsOnBasenameCollision) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/READONLY", "");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/dark.ini", "[Default]\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto themes = cm.getAllThemes();
+    ASSERT_EQ(themes.size(), 1);
+    EXPECT_EQ(wxFileName(themes[0]).GetPath(), tmp.path() + "/userdata/themes");
+}
+
+TEST_F(ConfigManagerTests, ThemePathReadOnlyPrefersUserOverride) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/READONLY", "");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/dark.ini", "[Default]\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto resolved = cm.themePath("themes/dark.ini");
+    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/userdata/themes");
+}
+
+TEST_F(ConfigManagerTests, ThemePathReadOnlyFallsBackToBundleWhenUserMissing) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/READONLY", "");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto resolved = cm.themePath("themes/dark.ini");
+    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
+}
+
+TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/themes/dark.ini", "[Default]\n");
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/dark.ini", "[Default]\n");
+
+    // No READONLY sentinel → user dir is ignored even though it exists.
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const auto resolved = cm.themePath("themes/dark.ini");
+    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
+}
+
 TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
     // Default-boot start with overlay-mode keywords. After
     // `reloadConfig(PATH)` flips to explicit mode, mutating and saving

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -50,43 +50,63 @@ public:
 private:
     wxString m_path;
 };
+
+/// Seed a minimal bundle layout under `<tmp>/ide/`. Writes the
+/// platform-specific config file, optionally drops the READONLY
+/// sentinel, and returns the ide dir path so the caller can pass it to
+/// the `ConfigManager` ctor.
+auto seedBundle(const TempDir& tmp, const wxString& configContents = "\n", const bool readOnly = false) -> wxString {
+    tmp.write("ide/" + ConfigManager::getPlatformConfigFileName(), configContents);
+    if (readOnly) {
+        tmp.write("ide/READONLY", "");
+    }
+    return tmp.path() + "/ide";
+}
+
+/// Compute the `<base>.local.ini` filename for the running platform's
+/// config — same logic as `ConfigStrategy::deriveOverlayPath` but just
+/// the basename, since these tests pick the path themselves.
+auto overlayBasename() -> wxString {
+    wxFileName fn(ConfigManager::getPlatformConfigFileName());
+    fn.SetName(fn.GetName() + ".local");
+    return fn.GetFullName();
+}
 } // namespace
 
 class ConfigManagerTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------
 // Per-category fallback when the backing file is missing
-// ---------------------------------------------------------------------------
-
-TEST_F(ConfigManagerTests, MissingKeywordsLoadsEmpty) {
-    TempDir tmp;
-    tmp.write("config.ini",
-        "version=0.5.0\n"
-        "keywords=does_not_exist.ini\n");
-
-    ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
-    auto& kw = cm.keywords();
-    // Empty fallback — every lookup returns the supplied default. The
-    // editor still launches; the user just has no keyword groups.
-    EXPECT_EQ(kw.get_or("groups.Keywords", wxString { "<sentinel>" }), "<sentinel>");
-}
-
-TEST_F(ConfigManagerTests, MissingShortcutsLoadsEmpty) {
-    TempDir tmp;
-    tmp.write("config.ini",
-        "version=0.5.0\n"
-        "shortcuts=does_not_exist.ini\n");
-
-    ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
-    auto& sc = cm.shortcuts();
-    EXPECT_EQ(sc.get_or("file.open", wxString { "<sentinel>" }), "<sentinel>");
-}
-
+//
 // Note: missing Config / Layout / Locale exits the process via
 // `fatalAndExit` (plain-English message-box → std::exit). Not covered
 // by direct tests because they would terminate the gtest runner. The
-// fallback paths above (Keywords / Shortcuts / Theme) are the ones
+// fallback paths below (Keywords / Shortcuts / Theme) are the ones
 // callers expect to keep going.
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigManagerTests, MissingNonFatalCategoriesLoadEmpty) {
+    struct Case {
+        ConfigManager::Category cat;
+        const char* configLine;
+        const char* lookupKey;
+    };
+    const Case cases[] = {
+        { ConfigManager::Category::Keywords, "keywords=does_not_exist.ini\n", "groups.Keywords" },
+        { ConfigManager::Category::Shortcuts, "shortcuts=does_not_exist.ini\n", "file.open" },
+    };
+    for (const auto& tc : cases) {
+        TempDir tmp;
+        tmp.write("config.ini", wxString::Format("version=0.5.0\n%s", tc.configLine));
+
+        ConfigManager cm(tmp.path(), tmp.path(), "config.ini");
+        EXPECT_EQ(
+            cm.get(tc.cat).get_or(tc.lookupKey, wxString { "<sentinel>" }),
+            "<sentinel>"
+        ) << "category="
+          << ConfigManager::getCategoryName(tc.cat);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Theme fallback — `m_theme.loadDefaults()` runs when the configured
@@ -120,48 +140,35 @@ TEST_F(ConfigManagerTests, MissingThemeEntryTriggersDefaults) {
 // Layered config — bundle base + .local.ini overlay
 //
 // These tests exercise the default-boot path (empty `configPath` → Overlay
-// strategy). They lay out a minimal bundle under <tmp>/ide/ and drive
-// READONLY routing via the `userDataDirOverride` ctor seam so nothing
-// touches the real platform user-data directory.
+// strategy). They lay out a minimal bundle under <tmp>/ide/ via
+// `seedBundle` and drive READONLY routing via the `userDataDirOverride`
+// ctor seam so nothing touches the real platform user-data directory.
 // ---------------------------------------------------------------------------
-
-namespace {
-/// Compute the `<base>.local.ini` filename for the running platform's
-/// config — same logic as `ConfigStrategy::deriveOverlayPath` but just
-/// the basename, since these tests pick the path themselves.
-auto overlayBasename(const wxString& configBasename) -> wxString {
-    wxFileName fn(configBasename);
-    fn.SetName(fn.GetName() + ".local");
-    return fn.GetFullName();
-}
-} // namespace
 
 TEST_F(ConfigManagerTests, DefaultBootPortableNoOverlayLoadsBundleAsIs) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
         "theme=dark\n");
 
     // No overlay file present — root must reflect bundle exactly.
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "4");
     EXPECT_EQ(cm.config().get_or("editor.theme", wxString { "<missing>" }), "dark");
 }
 
 TEST_F(ConfigManagerTests, DefaultBootOverlayMergesIntoConfigRoot) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
         "theme=dark\n");
-    tmp.write("ide/" + overlayBasename(cfgName),
+    tmp.write("ide/" + overlayBasename(),
         "[editor]\n"
         "tabSize=8\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     // Overlay wins where it diverges, bundle survives where it doesn't.
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "8");
     EXPECT_EQ(cm.config().get_or("editor.theme", wxString { "<missing>" }), "dark");
@@ -169,34 +176,31 @@ TEST_F(ConfigManagerTests, DefaultBootOverlayMergesIntoConfigRoot) {
 
 TEST_F(ConfigManagerTests, SaveMatchingBaselineProducesNoOverlayFile) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     // Mutate then revert — diff against baseline is empty.
     cm.config()["editor"]["tabSize"] = "8";
     cm.config()["editor"]["tabSize"] = "4";
     cm.save(ConfigManager::Category::Config);
 
-    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
-    EXPECT_FALSE(wxFileExists(overlayPath));
+    EXPECT_FALSE(wxFileExists(ideDir + "/" + overlayBasename()));
 }
 
 TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n"
         "theme=dark\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     cm.config()["editor"]["tabSize"] = "8";
     cm.save(ConfigManager::Category::Config);
 
-    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
+    const wxString overlayPath = ideDir + "/" + overlayBasename();
     ASSERT_TRUE(wxFileExists(overlayPath));
 
     // Parse the produced overlay and confirm it carries only the divergence.
@@ -210,43 +214,36 @@ TEST_F(ConfigManagerTests, SaveDivergentValueWritesPrunedOverlay) {
 
 TEST_F(ConfigManagerTests, SaveResetToBaselineDeletesExistingOverlay) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
         "tabSize=4\n");
     // Pre-existing overlay from a previous run that we now revert.
-    tmp.write("ide/" + overlayBasename(cfgName),
+    tmp.write("ide/" + overlayBasename(),
         "[editor]\n"
         "tabSize=8\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString {}), "8");
 
     cm.config()["editor"]["tabSize"] = "4";
     cm.save(ConfigManager::Category::Config);
 
-    const wxString overlayPath = tmp.path() + "/ide/" + overlayBasename(cfgName);
-    EXPECT_FALSE(wxFileExists(overlayPath));
+    EXPECT_FALSE(wxFileExists(ideDir + "/" + overlayBasename()));
 }
 
 TEST_F(ConfigManagerTests, ReadOnlyRoutesOverlayToUserDataDir) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
-        "tabSize=4\n");
-    tmp.write("ide/READONLY", "");
-    // userDataDir must exist before we try to write into it.
-    wxFileName::Mkdir(tmp.path() + "/userdata", 0755, wxPATH_MKDIR_FULL);
+        "tabSize=4\n",
+        /*readOnly=*/true);
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
     cm.config()["editor"]["tabSize"] = "8";
     cm.save(ConfigManager::Category::Config);
 
-    const wxString bundleOverlay = tmp.path() + "/ide/" + overlayBasename(cfgName);
-    const wxString userOverlay = tmp.path() + "/userdata/" + overlayBasename(cfgName);
-    EXPECT_FALSE(wxFileExists(bundleOverlay));
-    EXPECT_TRUE(wxFileExists(userOverlay));
+    EXPECT_FALSE(wxFileExists(ideDir + "/" + overlayBasename()));
+    EXPECT_TRUE(wxFileExists(tmp.path() + "/userdata/" + overlayBasename()));
 }
 
 TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
@@ -254,16 +251,15 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
     // ConfigManager pointing at the same dir, confirm the overlay is
     // picked up during load (not the absent bundle-adjacent one).
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName,
+    const auto ideDir = seedBundle(tmp,
         "[editor]\n"
-        "tabSize=4\n");
-    tmp.write("ide/READONLY", "");
-    tmp.write("userdata/" + overlayBasename(cfgName),
+        "tabSize=4\n",
+        /*readOnly=*/true);
+    tmp.write("userdata/" + overlayBasename(),
         "[editor]\n"
         "tabSize=12\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "12");
 }
 
@@ -273,15 +269,13 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
 
 TEST_F(ConfigManagerTests, GetAllThemesPortableEnumeratesBundleOnly) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
+    const auto ideDir = seedBundle(tmp);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("ide/themes/light.ini", "[Default]\n");
     // userdata exists but no READONLY — its themes/ must not contribute.
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
     tmp.write("userdata/themes/ignored.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 2);
@@ -291,16 +285,12 @@ TEST_F(ConfigManagerTests, GetAllThemesPortableEnumeratesBundleOnly) {
 
 TEST_F(ConfigManagerTests, GetAllThemesReadOnlyMergesBundleAndUserDirs) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
-    tmp.write("ide/READONLY", "");
+    const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
     tmp.write("ide/themes/light.ini", "[Default]\n");
-
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
     tmp.write("userdata/themes/solarized.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 3);
@@ -312,14 +302,11 @@ TEST_F(ConfigManagerTests, GetAllThemesReadOnlyMergesBundleAndUserDirs) {
 
 TEST_F(ConfigManagerTests, GetAllThemesUserDirWinsOnBasenameCollision) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
-    tmp.write("ide/READONLY", "");
+    const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
     const auto themes = cm.getAllThemes();
     ASSERT_EQ(themes.size(), 1);
@@ -328,46 +315,44 @@ TEST_F(ConfigManagerTests, GetAllThemesUserDirWinsOnBasenameCollision) {
 
 TEST_F(ConfigManagerTests, ThemePathReadOnlyPrefersUserOverride) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
-    tmp.write("ide/READONLY", "");
+    const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
-    const auto resolved = cm.themePath("themes/dark.ini");
-    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/userdata/themes");
+    EXPECT_EQ(
+        wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
+        tmp.path() + "/userdata/themes"
+    );
 }
 
 TEST_F(ConfigManagerTests, ThemePathReadOnlyFallsBackToBundleWhenUserMissing) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
-    tmp.write("ide/READONLY", "");
+    const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
-    const auto resolved = cm.themePath("themes/dark.ini");
-    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
+    EXPECT_EQ(
+        wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
+        ideDir + "/themes"
+    );
 }
 
 TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
+    const auto ideDir = seedBundle(tmp);
     tmp.write("ide/themes/dark.ini", "[Default]\n");
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
     tmp.write("userdata/themes/dark.ini", "[Default]\n");
 
     // No READONLY sentinel → user dir is ignored even though it exists.
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
-    const auto resolved = cm.themePath("themes/dark.ini");
-    EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
+    EXPECT_EQ(
+        wxFileName(cm.themePath("themes/dark.ini")).GetPath(),
+        ideDir + "/themes"
+    );
 }
 
 TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
@@ -378,13 +363,12 @@ TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
     // mutation does not reach disk, and the on-disk file is byte-for-
     // byte unchanged.
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "locale=locales/en.ini\n");
+    const auto ideDir = seedBundle(tmp, "locale=locales/en.ini\n");
     tmp.write("ide/locales/en.ini",
         "[strings]\n"
         "greeting=Hello\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     ASSERT_EQ(cm.locale().get_or("strings.greeting", wxString {}), "Hello");
 
     // Mutate in-memory then attempt to persist. For any other category
@@ -392,7 +376,7 @@ TEST_F(ConfigManagerTests, SaveLocaleIsRefusedAndLeavesBundleFileUntouched) {
     cm.locale()["strings"]["greeting"] = "Bonjour";
     cm.save(ConfigManager::Category::Locale);
 
-    wxFFileInputStream roundTripStream(tmp.path() + "/ide/locales/en.ini");
+    wxFFileInputStream roundTripStream(ideDir + "/locales/en.ini");
     wxFileConfig roundTrip(roundTripStream, wxConvUTF8);
     wxString value;
     ASSERT_TRUE(roundTrip.Read("strings/greeting", &value));
@@ -407,16 +391,15 @@ TEST_F(ConfigManagerTests, RelativeOfUserDataPathStripsUserDataPrefix) {
     // storing the full absolute path and leaks the user's home dir
     // into the overlay file.
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
-    tmp.write("ide/READONLY", "");
-    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    const auto ideDir = seedBundle(tmp, "\n", /*readOnly=*/true);
     tmp.write("userdata/themes/modern-dark.ini", "[Default]\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+    ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
 
-    const wxString userThemeAbs = tmp.path() + "/userdata/themes/modern-dark.ini";
-    EXPECT_EQ(cm.relative(userThemeAbs), "themes/modern-dark.ini");
+    EXPECT_EQ(
+        cm.relative(tmp.path() + "/userdata/themes/modern-dark.ini"),
+        "themes/modern-dark.ini"
+    );
 }
 
 TEST_F(ConfigManagerTests, ThemesWriteDirRoutesByReadOnly) {
@@ -424,19 +407,18 @@ TEST_F(ConfigManagerTests, ThemesWriteDirRoutesByReadOnly) {
     // the rule ThemePage::onSaveTheme uses to redirect save targets so
     // edits to a bundle-shipped theme land in the user-writable copy.
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "\n");
+    const auto ideDir = seedBundle(tmp);
 
     // Portable
     {
-        ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
-        EXPECT_EQ(cm.themesWriteDir(), tmp.path() + "/ide/themes");
+        ConfigManager cm(tmp.path(), ideDir, "");
+        EXPECT_EQ(cm.themesWriteDir(), ideDir + "/themes");
     }
 
     // READONLY routes to user dir
     tmp.write("ide/READONLY", "");
     {
-        ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+        ConfigManager cm(tmp.path(), ideDir, "", tmp.path() + "/userdata");
         EXPECT_EQ(cm.themesWriteDir(), tmp.path() + "/userdata/themes");
     }
 }
@@ -448,8 +430,7 @@ TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
     // produced, because the sub-category strategy was rebuilt under
     // the new mode.
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "keywords=keywords.ini\n");
+    const auto ideDir = seedBundle(tmp, "keywords=keywords.ini\n");
     tmp.write("ide/keywords.ini",
         "[functions]\n"
         "Print=1\n");
@@ -458,7 +439,7 @@ TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
         "[functions]\n"
         "Foo=1\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    ConfigManager cm(tmp.path(), ideDir, "");
     EXPECT_EQ(cm.keywords().get_or("functions.Print", wxString { "<missing>" }), "1");
 
     cm.reloadConfig(tmp.path() + "/explicit.ini");
@@ -485,8 +466,7 @@ TEST_F(ConfigManagerTests, SetCategoryPathInheritsBootModeStrategy) {
     // which calls `buildStrategy()` under the current mode (Overlay),
     // so the new sub-category gets an overlay path alongside its base.
     TempDir tmp;
-    const auto cfgName = ConfigManager::getPlatformConfigFileName();
-    tmp.write("ide/" + cfgName, "keywords=keywords.ini\n");
+    const auto ideDir = seedBundle(tmp, "keywords=keywords.ini\n");
     tmp.write("ide/keywords.ini",
         "[functions]\n"
         "Print=1\n");
@@ -494,8 +474,8 @@ TEST_F(ConfigManagerTests, SetCategoryPathInheritsBootModeStrategy) {
         "[functions]\n"
         "Alt=1\n");
 
-    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
-    cm.setCategoryPath(ConfigManager::Category::Keywords, tmp.path() + "/ide/alt_keywords.ini");
+    ConfigManager cm(tmp.path(), ideDir, "");
+    cm.setCategoryPath(ConfigManager::Category::Keywords, ideDir + "/alt_keywords.ini");
 
     EXPECT_EQ(cm.keywords().get_or("functions.Alt", wxString { "<missing>" }), "1");
     EXPECT_EQ(cm.keywords().get_or("functions.Print", wxString { "<missing>" }), "<missing>");
@@ -504,7 +484,7 @@ TEST_F(ConfigManagerTests, SetCategoryPathInheritsBootModeStrategy) {
     cm.save(ConfigManager::Category::Keywords);
 
     // Overlay mode inherits → `.local.ini` lands next to the new base.
-    EXPECT_TRUE(wxFileExists(tmp.path() + "/ide/alt_keywords.local.ini"));
+    EXPECT_TRUE(wxFileExists(ideDir + "/alt_keywords.local.ini"));
 }
 
 TEST_F(ConfigManagerTests, ExplicitConfigPathBypassesOverlay) {

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -370,6 +370,26 @@ TEST_F(ConfigManagerTests, ThemePathPortableIgnoresUserDir) {
     EXPECT_EQ(wxFileName(resolved).GetPath(), tmp.path() + "/ide/themes");
 }
 
+TEST_F(ConfigManagerTests, RelativeOfUserDataPathStripsUserDataPrefix) {
+    // Regression: under READONLY, `themesWriteDir()` returns
+    // `<UserDataDir>/themes/`, so a theme saved there yields an absolute
+    // path. `relative()` must strip the `m_userDataDir` prefix the same
+    // way it strips `m_ideDir` — otherwise `config["theme"]` ends up
+    // storing the full absolute path and leaks the user's home dir
+    // into the overlay file.
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "\n");
+    tmp.write("ide/READONLY", "");
+    wxFileName::Mkdir(tmp.path() + "/userdata/themes", 0755, wxPATH_MKDIR_FULL);
+    tmp.write("userdata/themes/modern-dark.ini", "[Default]\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "", tmp.path() + "/userdata");
+
+    const wxString userThemeAbs = tmp.path() + "/userdata/themes/modern-dark.ini";
+    EXPECT_EQ(cm.relative(userThemeAbs), "themes/modern-dark.ini");
+}
+
 TEST_F(ConfigManagerTests, ThemesWriteDirRoutesByReadOnly) {
     // Portable → bundle themes dir; READONLY → user themes dir. This is
     // the rule ThemePage::onSaveTheme uses to redirect save targets so

--- a/tests/unit/ConfigManagerTests.cpp
+++ b/tests/unit/ConfigManagerTests.cpp
@@ -267,6 +267,72 @@ TEST_F(ConfigManagerTests, ReadOnlyLoadsOverlayFromUserDataDir) {
     EXPECT_EQ(cm.config().get_or("editor.tabSize", wxString { "<missing>" }), "12");
 }
 
+TEST_F(ConfigManagerTests, ReloadConfigCascadesSubCategoriesToDirectMode) {
+    // Default-boot start with overlay-mode keywords. After
+    // `reloadConfig(PATH)` flips to explicit mode, mutating and saving
+    // keywords must hit the base file directly — no `.local.ini` is
+    // produced, because the sub-category strategy was rebuilt under
+    // the new mode.
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "keywords=keywords.ini\n");
+    tmp.write("ide/keywords.ini",
+        "[functions]\n"
+        "Print=1\n");
+    tmp.write("explicit.ini", "keywords=alt_keywords.ini\n");
+    tmp.write("alt_keywords.ini",
+        "[functions]\n"
+        "Foo=1\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    EXPECT_EQ(cm.keywords().get_or("functions.Print", wxString { "<missing>" }), "1");
+
+    cm.reloadConfig(tmp.path() + "/explicit.ini");
+
+    // New keywords visible; old keywords gone.
+    EXPECT_EQ(cm.keywords().get_or("functions.Foo", wxString { "<missing>" }), "1");
+    EXPECT_EQ(cm.keywords().get_or("functions.Print", wxString { "<missing>" }), "<missing>");
+
+    // Mutate + save. Direct mode → base file overwritten, no overlay.
+    cm.keywords()["functions"]["Bar"] = "1";
+    cm.save(ConfigManager::Category::Keywords);
+
+    EXPECT_FALSE(wxFileExists(tmp.path() + "/alt_keywords.local.ini"));
+
+    wxFFileInputStream in(tmp.path() + "/alt_keywords.ini");
+    wxFileConfig produced(in, wxConvUTF8);
+    wxString value;
+    EXPECT_TRUE(produced.Read("functions/Bar", &value));
+    EXPECT_EQ(value, "1");
+}
+
+TEST_F(ConfigManagerTests, SetCategoryPathInheritsBootModeStrategy) {
+    // Default-boot rotation. `setCategoryPath` flows through `load()`
+    // which calls `buildStrategy()` under the current mode (Overlay),
+    // so the new sub-category gets an overlay path alongside its base.
+    TempDir tmp;
+    const auto cfgName = ConfigManager::getPlatformConfigFileName();
+    tmp.write("ide/" + cfgName, "keywords=keywords.ini\n");
+    tmp.write("ide/keywords.ini",
+        "[functions]\n"
+        "Print=1\n");
+    tmp.write("ide/alt_keywords.ini",
+        "[functions]\n"
+        "Alt=1\n");
+
+    ConfigManager cm(tmp.path(), tmp.path() + "/ide", "");
+    cm.setCategoryPath(ConfigManager::Category::Keywords, tmp.path() + "/ide/alt_keywords.ini");
+
+    EXPECT_EQ(cm.keywords().get_or("functions.Alt", wxString { "<missing>" }), "1");
+    EXPECT_EQ(cm.keywords().get_or("functions.Print", wxString { "<missing>" }), "<missing>");
+
+    cm.keywords()["functions"]["Bar"] = "1";
+    cm.save(ConfigManager::Category::Keywords);
+
+    // Overlay mode inherits → `.local.ini` lands next to the new base.
+    EXPECT_TRUE(wxFileExists(tmp.path() + "/ide/alt_keywords.local.ini"));
+}
+
 TEST_F(ConfigManagerTests, ExplicitConfigPathBypassesOverlay) {
     // `--config=PATH` semantics: even with READONLY sentinel and an
     // overlay file alongside, the explicit path is treated as a single

--- a/tests/unit/ConfigStrategyTests.cpp
+++ b/tests/unit/ConfigStrategyTests.cpp
@@ -12,48 +12,28 @@ using namespace fbide;
 class ConfigStrategyTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------
-// Overlay strategy — bundle baseline + writable user overlay
+// Overlay strategy — bundle baseline + writable user overlay. savePath()
+// must point at the overlay so saves never write the immutable bundle.
 // ---------------------------------------------------------------------------
 
-TEST_F(ConfigStrategyTests, OverlayCarriesBothPaths) {
+TEST_F(ConfigStrategyTests, OverlayExposesAllAccessors) {
     const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
     EXPECT_EQ(strat.basePath(), "/ide/config.ini");
     EXPECT_EQ(strat.overlayPath(), "/user/config.local.ini");
-}
-
-TEST_F(ConfigStrategyTests, OverlaySavesToOverlayPath) {
-    // Saves under the Overlay strategy must land in the writable .local.ini,
-    // never in the immutable bundle file. savePath() encodes that rule so
-    // ConfigManager::save() can stay agnostic of strategy mode.
-    const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
     EXPECT_EQ(strat.savePath(), strat.overlayPath());
-}
-
-TEST_F(ConfigStrategyTests, OverlayUsesOverlay) {
-    const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
     EXPECT_TRUE(strat.usesOverlay());
 }
 
 // ---------------------------------------------------------------------------
-// Direct strategy — single file, no layering (--config=PATH at startup, or
-// reloadConfig() at runtime)
+// Direct strategy — single file, no layering (--config=PATH at startup or
+// reloadConfig() at runtime). savePath() collapses to basePath().
 // ---------------------------------------------------------------------------
 
-TEST_F(ConfigStrategyTests, DirectCarriesOnlyBasePath) {
+TEST_F(ConfigStrategyTests, DirectExposesAllAccessors) {
     const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
     EXPECT_EQ(strat.basePath(), "/tmp/ci-config.ini");
     EXPECT_TRUE(strat.overlayPath().IsEmpty());
-}
-
-TEST_F(ConfigStrategyTests, DirectSavesToBasePath) {
-    // Explicit-path mode round-trips: load and save target the same file. No
-    // overlay file is ever produced.
-    const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
     EXPECT_EQ(strat.savePath(), strat.basePath());
-}
-
-TEST_F(ConfigStrategyTests, DirectDoesNotUseOverlay) {
-    const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
     EXPECT_FALSE(strat.usesOverlay());
 }
 
@@ -88,11 +68,6 @@ TEST_F(ConfigStrategyTests, DeriveOverlayPathReadOnlyRoutesToUserDir) {
     const auto path = ConfigStrategy::deriveOverlayPath(base, userDataDir, /*readOnly=*/true);
     EXPECT_EQ(wxFileName(path).GetFullName(), "config_macos.local.ini");
     EXPECT_EQ(wxFileName(path).GetPath(), userDataDir);
-}
-
-TEST_F(ConfigStrategyTests, DeriveOverlayPathKeywordsFile) {
-    const auto path = ConfigStrategy::deriveOverlayPath("/ide/keywords.ini", "", false);
-    EXPECT_EQ(wxFileName(path).GetFullName(), "keywords.local.ini");
 }
 
 TEST_F(ConfigStrategyTests, DeriveOverlayPathPreservesExtension) {

--- a/tests/unit/ConfigStrategyTests.cpp
+++ b/tests/unit/ConfigStrategyTests.cpp
@@ -4,9 +4,11 @@
 // Licensed under the MIT License. See LICENSE file for details.
 // https://github.com/albeva/fbide
 //
+#include <filesystem>
 #include <gtest/gtest.h>
 #include "config/ConfigStrategy.hpp"
 
+namespace fs = std::filesystem;
 using namespace fbide;
 
 class ConfigStrategyTests : public testing::Test {};
@@ -18,8 +20,8 @@ class ConfigStrategyTests : public testing::Test {};
 
 TEST_F(ConfigStrategyTests, OverlayExposesAllAccessors) {
     const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
-    EXPECT_EQ(strat.basePath(), "/ide/config.ini");
-    EXPECT_EQ(strat.overlayPath(), "/user/config.local.ini");
+    EXPECT_EQ(strat.basePath(), fs::path { "/ide/config.ini" });
+    EXPECT_EQ(strat.overlayPath(), fs::path { "/user/config.local.ini" });
     EXPECT_EQ(strat.savePath(), strat.overlayPath());
     EXPECT_TRUE(strat.usesOverlay());
 }
@@ -31,8 +33,8 @@ TEST_F(ConfigStrategyTests, OverlayExposesAllAccessors) {
 
 TEST_F(ConfigStrategyTests, DirectExposesAllAccessors) {
     const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
-    EXPECT_EQ(strat.basePath(), "/tmp/ci-config.ini");
-    EXPECT_TRUE(strat.overlayPath().IsEmpty());
+    EXPECT_EQ(strat.basePath(), fs::path { "/tmp/ci-config.ini" });
+    EXPECT_TRUE(strat.overlayPath().empty());
     EXPECT_EQ(strat.savePath(), strat.basePath());
     EXPECT_FALSE(strat.usesOverlay());
 }
@@ -45,8 +47,8 @@ TEST_F(ConfigStrategyTests, DirectExposesAllAccessors) {
 TEST_F(ConfigStrategyTests, IsCopyable) {
     const auto original = ConfigStrategy::overlay("/a", "/b");
     const auto copy = original;
-    EXPECT_EQ(copy.basePath(), "/a");
-    EXPECT_EQ(copy.overlayPath(), "/b");
+    EXPECT_EQ(copy.basePath(), fs::path { "/a" });
+    EXPECT_EQ(copy.overlayPath(), fs::path { "/b" });
     EXPECT_TRUE(copy.usesOverlay());
 }
 
@@ -56,25 +58,25 @@ TEST_F(ConfigStrategyTests, IsCopyable) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ConfigStrategyTests, DeriveOverlayPathPortableLivesNextToBase) {
-    const wxString base = "/ide/config_macos.ini";
+    const fs::path base = "/ide/config_macos.ini";
     const auto path = ConfigStrategy::deriveOverlayPath(base, "/anything", /*readOnly=*/false);
-    EXPECT_EQ(wxFileName(path).GetFullName(), "config_macos.local.ini");
-    EXPECT_EQ(wxFileName(path).GetPath(), wxFileName(base).GetPath());
+    EXPECT_EQ(path.filename(), "config_macos.local.ini");
+    EXPECT_EQ(path.parent_path(), base.parent_path());
 }
 
 TEST_F(ConfigStrategyTests, DeriveOverlayPathReadOnlyRoutesToUserDir) {
-    const wxString base = "/ide/config_macos.ini";
-    const wxString userDataDir = "/user/Library/Application Support/fbide";
+    const fs::path base = "/ide/config_macos.ini";
+    const fs::path userDataDir = "/user/Library/Application Support/fbide";
     const auto path = ConfigStrategy::deriveOverlayPath(base, userDataDir, /*readOnly=*/true);
-    EXPECT_EQ(wxFileName(path).GetFullName(), "config_macos.local.ini");
-    EXPECT_EQ(wxFileName(path).GetPath(), userDataDir);
+    EXPECT_EQ(path.filename(), "config_macos.local.ini");
+    EXPECT_EQ(path.parent_path(), userDataDir);
 }
 
 TEST_F(ConfigStrategyTests, DeriveOverlayPathPreservesExtension) {
     // Theme ".ini" today; ".fbt" legacy. Either should round-trip with
     // ".local" inserted before the extension, not appended after it.
     const auto fbt = ConfigStrategy::deriveOverlayPath("/themes/dark.fbt", "", false);
-    EXPECT_EQ(wxFileName(fbt).GetFullName(), "dark.local.fbt");
+    EXPECT_EQ(fbt.filename(), "dark.local.fbt");
 }
 
 // ---------------------------------------------------------------------------
@@ -90,7 +92,7 @@ TEST_F(ConfigStrategyTests, SelectBundleOnlyCategoryAlwaysDirect) {
         /*overlayCapable=*/false, /*explicitMode=*/false
     );
     EXPECT_FALSE(strat.usesOverlay());
-    EXPECT_EQ(strat.basePath(), "/ide/locales/en.ini");
+    EXPECT_EQ(strat.basePath(), fs::path { "/ide/locales/en.ini" });
 }
 
 TEST_F(ConfigStrategyTests, SelectExplicitModeForcesDirect) {
@@ -102,30 +104,30 @@ TEST_F(ConfigStrategyTests, SelectExplicitModeForcesDirect) {
         /*overlayCapable=*/true, /*explicitMode=*/true
     );
     EXPECT_FALSE(strat.usesOverlay());
-    EXPECT_EQ(strat.basePath(), "/tmp/ci.ini");
+    EXPECT_EQ(strat.basePath(), fs::path { "/tmp/ci.ini" });
 }
 
 TEST_F(ConfigStrategyTests, SelectDefaultBootPortableProducesOverlayNextToBase) {
-    const wxString base = "/ide/config_macos.ini";
+    const fs::path base = "/ide/config_macos.ini";
     const auto strat = ConfigStrategy::select(
         base, "/user", /*readOnly=*/false,
         /*overlayCapable=*/true, /*explicitMode=*/false
     );
     EXPECT_TRUE(strat.usesOverlay());
     EXPECT_EQ(strat.basePath(), base);
-    EXPECT_EQ(wxFileName(strat.overlayPath()).GetFullName(), "config_macos.local.ini");
-    EXPECT_EQ(wxFileName(strat.overlayPath()).GetPath(), wxFileName(base).GetPath());
+    EXPECT_EQ(strat.overlayPath().filename(), "config_macos.local.ini");
+    EXPECT_EQ(strat.overlayPath().parent_path(), base.parent_path());
 }
 
 TEST_F(ConfigStrategyTests, SelectDefaultBootReadOnlyRoutesOverlayToUserDir) {
-    const wxString base = "/ide/config_macos.ini";
-    const wxString userDataDir = "/user/Library/Application Support/fbide";
+    const fs::path base = "/ide/config_macos.ini";
+    const fs::path userDataDir = "/user/Library/Application Support/fbide";
     const auto strat = ConfigStrategy::select(
         base, userDataDir, /*readOnly=*/true,
         /*overlayCapable=*/true, /*explicitMode=*/false
     );
     EXPECT_TRUE(strat.usesOverlay());
     EXPECT_EQ(strat.basePath(), base);
-    EXPECT_EQ(wxFileName(strat.overlayPath()).GetFullName(), "config_macos.local.ini");
-    EXPECT_EQ(wxFileName(strat.overlayPath()).GetPath(), userDataDir);
+    EXPECT_EQ(strat.overlayPath().filename(), "config_macos.local.ini");
+    EXPECT_EQ(strat.overlayPath().parent_path(), userDataDir);
 }

--- a/tests/unit/ConfigStrategyTests.cpp
+++ b/tests/unit/ConfigStrategyTests.cpp
@@ -11,6 +11,9 @@
 namespace fs = std::filesystem;
 using namespace fbide;
 
+// gtest fixtures are referenced by TEST_F macro expansion and
+// idiomatically stay at file scope.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 class ConfigStrategyTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------
@@ -46,7 +49,9 @@ TEST_F(ConfigStrategyTests, DirectExposesAllAccessors) {
 
 TEST_F(ConfigStrategyTests, IsCopyable) {
     const auto original = ConfigStrategy::overlay("/a", "/b");
-    const auto copy = original;
+    // Force a real copy rather than relying on copy-elision so the
+    // test actually exercises the copy constructor.
+    auto copy = original; // NOLINT(performance-unnecessary-copy-initialization)
     EXPECT_EQ(copy.basePath(), fs::path { "/a" });
     EXPECT_EQ(copy.overlayPath(), fs::path { "/b" });
     EXPECT_TRUE(copy.usesOverlay());

--- a/tests/unit/ConfigStrategyTests.cpp
+++ b/tests/unit/ConfigStrategyTests.cpp
@@ -1,0 +1,156 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include <gtest/gtest.h>
+#include "config/ConfigStrategy.hpp"
+
+using namespace fbide;
+
+class ConfigStrategyTests : public testing::Test {};
+
+// ---------------------------------------------------------------------------
+// Overlay strategy — bundle baseline + writable user overlay
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigStrategyTests, OverlayCarriesBothPaths) {
+    const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
+    EXPECT_EQ(strat.basePath(), "/ide/config.ini");
+    EXPECT_EQ(strat.overlayPath(), "/user/config.local.ini");
+}
+
+TEST_F(ConfigStrategyTests, OverlaySavesToOverlayPath) {
+    // Saves under the Overlay strategy must land in the writable .local.ini,
+    // never in the immutable bundle file. savePath() encodes that rule so
+    // ConfigManager::save() can stay agnostic of strategy mode.
+    const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
+    EXPECT_EQ(strat.savePath(), strat.overlayPath());
+}
+
+TEST_F(ConfigStrategyTests, OverlayUsesOverlay) {
+    const auto strat = ConfigStrategy::overlay("/ide/config.ini", "/user/config.local.ini");
+    EXPECT_TRUE(strat.usesOverlay());
+}
+
+// ---------------------------------------------------------------------------
+// Direct strategy — single file, no layering (--config=PATH at startup, or
+// reloadConfig() at runtime)
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigStrategyTests, DirectCarriesOnlyBasePath) {
+    const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
+    EXPECT_EQ(strat.basePath(), "/tmp/ci-config.ini");
+    EXPECT_TRUE(strat.overlayPath().IsEmpty());
+}
+
+TEST_F(ConfigStrategyTests, DirectSavesToBasePath) {
+    // Explicit-path mode round-trips: load and save target the same file. No
+    // overlay file is ever produced.
+    const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
+    EXPECT_EQ(strat.savePath(), strat.basePath());
+}
+
+TEST_F(ConfigStrategyTests, DirectDoesNotUseOverlay) {
+    const auto strat = ConfigStrategy::direct("/tmp/ci-config.ini");
+    EXPECT_FALSE(strat.usesOverlay());
+}
+
+// ---------------------------------------------------------------------------
+// Value-type behaviour — must be copyable / movable so ConfigManager can
+// keep a strategy per Entry without ceremony.
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigStrategyTests, IsCopyable) {
+    const auto original = ConfigStrategy::overlay("/a", "/b");
+    const auto copy = original;
+    EXPECT_EQ(copy.basePath(), "/a");
+    EXPECT_EQ(copy.overlayPath(), "/b");
+    EXPECT_TRUE(copy.usesOverlay());
+}
+
+// ---------------------------------------------------------------------------
+// deriveOverlayPath — pure path transform. Inserts ".local" before the
+// extension; routes to <userDataDir> when READONLY, else stays next to base.
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigStrategyTests, DeriveOverlayPathPortableLivesNextToBase) {
+    const wxString base = "/ide/config_macos.ini";
+    const auto path = ConfigStrategy::deriveOverlayPath(base, "/anything", /*readOnly=*/false);
+    EXPECT_EQ(wxFileName(path).GetFullName(), "config_macos.local.ini");
+    EXPECT_EQ(wxFileName(path).GetPath(), wxFileName(base).GetPath());
+}
+
+TEST_F(ConfigStrategyTests, DeriveOverlayPathReadOnlyRoutesToUserDir) {
+    const wxString base = "/ide/config_macos.ini";
+    const wxString userDataDir = "/user/Library/Application Support/fbide";
+    const auto path = ConfigStrategy::deriveOverlayPath(base, userDataDir, /*readOnly=*/true);
+    EXPECT_EQ(wxFileName(path).GetFullName(), "config_macos.local.ini");
+    EXPECT_EQ(wxFileName(path).GetPath(), userDataDir);
+}
+
+TEST_F(ConfigStrategyTests, DeriveOverlayPathKeywordsFile) {
+    const auto path = ConfigStrategy::deriveOverlayPath("/ide/keywords.ini", "", false);
+    EXPECT_EQ(wxFileName(path).GetFullName(), "keywords.local.ini");
+}
+
+TEST_F(ConfigStrategyTests, DeriveOverlayPathPreservesExtension) {
+    // Theme ".ini" today; ".fbt" legacy. Either should round-trip with
+    // ".local" inserted before the extension, not appended after it.
+    const auto fbt = ConfigStrategy::deriveOverlayPath("/themes/dark.fbt", "", false);
+    EXPECT_EQ(wxFileName(fbt).GetFullName(), "dark.local.fbt");
+}
+
+// ---------------------------------------------------------------------------
+// select — top-level rule. Two axes (explicitMode, overlayCapable) collapse
+// to Direct; only the (overlayCapable && !explicitMode) cell is Overlay.
+// ---------------------------------------------------------------------------
+
+TEST_F(ConfigStrategyTests, SelectBundleOnlyCategoryAlwaysDirect) {
+    // overlayCapable=false → locale (and any other bundle-only slot).
+    // Direct regardless of explicitMode / readOnly.
+    const auto strat = ConfigStrategy::select(
+        "/ide/locales/en.ini", "/user", /*readOnly=*/true,
+        /*overlayCapable=*/false, /*explicitMode=*/false
+    );
+    EXPECT_FALSE(strat.usesOverlay());
+    EXPECT_EQ(strat.basePath(), "/ide/locales/en.ini");
+}
+
+TEST_F(ConfigStrategyTests, SelectExplicitModeForcesDirect) {
+    // --config=PATH (or runtime reloadConfig) → Direct for every category.
+    // Reproducibility/CI rule: no overlays sneak in on top of an explicit
+    // single-file config.
+    const auto strat = ConfigStrategy::select(
+        "/tmp/ci.ini", "/user", /*readOnly=*/true,
+        /*overlayCapable=*/true, /*explicitMode=*/true
+    );
+    EXPECT_FALSE(strat.usesOverlay());
+    EXPECT_EQ(strat.basePath(), "/tmp/ci.ini");
+}
+
+TEST_F(ConfigStrategyTests, SelectDefaultBootPortableProducesOverlayNextToBase) {
+    const wxString base = "/ide/config_macos.ini";
+    const auto strat = ConfigStrategy::select(
+        base, "/user", /*readOnly=*/false,
+        /*overlayCapable=*/true, /*explicitMode=*/false
+    );
+    EXPECT_TRUE(strat.usesOverlay());
+    EXPECT_EQ(strat.basePath(), base);
+    EXPECT_EQ(wxFileName(strat.overlayPath()).GetFullName(), "config_macos.local.ini");
+    EXPECT_EQ(wxFileName(strat.overlayPath()).GetPath(), wxFileName(base).GetPath());
+}
+
+TEST_F(ConfigStrategyTests, SelectDefaultBootReadOnlyRoutesOverlayToUserDir) {
+    const wxString base = "/ide/config_macos.ini";
+    const wxString userDataDir = "/user/Library/Application Support/fbide";
+    const auto strat = ConfigStrategy::select(
+        base, userDataDir, /*readOnly=*/true,
+        /*overlayCapable=*/true, /*explicitMode=*/false
+    );
+    EXPECT_TRUE(strat.usesOverlay());
+    EXPECT_EQ(strat.basePath(), base);
+    EXPECT_EQ(wxFileName(strat.overlayPath()).GetFullName(), "config_macos.local.ini");
+    EXPECT_EQ(wxFileName(strat.overlayPath()).GetPath(), userDataDir);
+}

--- a/tests/unit/ValueDiffTests.cpp
+++ b/tests/unit/ValueDiffTests.cpp
@@ -9,6 +9,9 @@
 
 using namespace fbide;
 
+// gtest fixtures are referenced by TEST_F macro expansion and
+// idiomatically stay at file scope.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 class ValueDiffTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/ValueDiffTests.cpp
+++ b/tests/unit/ValueDiffTests.cpp
@@ -1,0 +1,164 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include <gtest/gtest.h>
+#include "config/Value.hpp"
+
+using namespace fbide;
+
+class ValueDiffTests : public testing::Test {};
+
+// ---------------------------------------------------------------------------
+// Identity / empty
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueDiffTests, IdenticalTreesProduceEmptyDiff) {
+    Value merged;
+    merged["foo"] = "x";
+    merged["nested"]["a"] = "1";
+
+    Value baseline;
+    baseline["foo"] = "x";
+    baseline["nested"]["a"] = "1";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_FALSE(static_cast<bool>(diff));
+}
+
+TEST_F(ValueDiffTests, EmptyMergedProducesEmptyDiff) {
+    const Value merged;
+    Value baseline;
+    baseline["foo"] = "x";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_FALSE(static_cast<bool>(diff));
+}
+
+// ---------------------------------------------------------------------------
+// Leaf-level divergences
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueDiffTests, SingleDifferingLeafProducesSingleEntry) {
+    Value merged;
+    merged["foo"] = "user";
+    merged["bar"] = "same";
+
+    Value baseline;
+    baseline["foo"] = "bundle";
+    baseline["bar"] = "same";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("foo", wxString { "<missing>" }), "user");
+    // "bar" matches baseline → must not appear in diff
+    EXPECT_EQ(diff.get_or("bar", wxString { "<missing>" }), "<missing>");
+}
+
+TEST_F(ValueDiffTests, NewKeyInMergedNotInBaselineIsIncluded) {
+    Value merged;
+    merged["foo"] = "bundle";
+    merged["added"] = "new";
+
+    Value baseline;
+    baseline["foo"] = "bundle";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("added", wxString { "<missing>" }), "new");
+    EXPECT_EQ(diff.get_or("foo", wxString { "<missing>" }), "<missing>");
+}
+
+TEST_F(ValueDiffTests, KeyInBaselineNotInMergedIsExcluded) {
+    // Deletion semantics are not expressed via the diff (the user would
+    // edit the overlay file directly to express "remove this bundle key").
+    // The diff persists only what's present in merged.
+    Value merged;
+    merged["keep"] = "x";
+
+    Value baseline;
+    baseline["keep"] = "x";
+    baseline["removed"] = "y";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_FALSE(static_cast<bool>(diff));
+}
+
+TEST_F(ValueDiffTests, EmptyStringInMergedDifferingFromBaselineIsIncluded) {
+    // Aggressive prune rule applies to *equal* values; an empty string
+    // that differs from baseline is still a real divergence and must be
+    // emitted so the overlay records "this key is intentionally blank".
+    Value merged;
+    merged["foo"] = "";
+
+    Value baseline;
+    baseline["foo"] = "bundle";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("foo", wxString { "<missing>" }), "");
+}
+
+// ---------------------------------------------------------------------------
+// Nested groups — parent groups synthesised only when they contain a divergence
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueDiffTests, NestedGroupsOnlyDivergentSubPathsRetained) {
+    Value merged;
+    merged["editor"]["tabSize"] = "8";  // diverges from baseline
+    merged["editor"]["theme"] = "dark"; // matches baseline
+    merged["compiler"]["path"] = "fbc"; // matches baseline
+
+    Value baseline;
+    baseline["editor"]["tabSize"] = "4";
+    baseline["editor"]["theme"] = "dark";
+    baseline["compiler"]["path"] = "fbc";
+
+    const auto diff = merged.diffAgainst(baseline);
+    // editor.tabSize present, editor.theme absent, compiler.* absent
+    EXPECT_EQ(diff.get_or("editor.tabSize", wxString { "<missing>" }), "8");
+    EXPECT_EQ(diff.get_or("editor.theme", wxString { "<missing>" }), "<missing>");
+    EXPECT_EQ(diff.get_or("compiler.path", wxString { "<missing>" }), "<missing>");
+}
+
+TEST_F(ValueDiffTests, DeeplyNestedDivergenceSynthesisesParentGroups) {
+    Value merged;
+    merged["a"]["b"]["c"] = "user";
+    merged["a"]["b"]["d"] = "same";
+
+    Value baseline;
+    baseline["a"]["b"]["c"] = "bundle";
+    baseline["a"]["b"]["d"] = "same";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("a.b.c", wxString { "<missing>" }), "user");
+    EXPECT_EQ(diff.get_or("a.b.d", wxString { "<missing>" }), "<missing>");
+}
+
+// ---------------------------------------------------------------------------
+// Type mismatches — overlay always wins; matches mergeFrom symmetry
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueDiffTests, TypeMismatchMergedLeafOverBaselineGroup) {
+    // Pathological — INI overlays mirror base structure. But if the
+    // merged tree has a leaf where baseline has a group, the leaf is a
+    // divergence and must be persisted.
+    Value merged;
+    merged["foo"] = "leaf";
+
+    Value baseline;
+    baseline["foo"]["x"] = "1";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("foo", wxString { "<missing>" }), "leaf");
+}
+
+TEST_F(ValueDiffTests, TypeMismatchMergedGroupOverBaselineLeaf) {
+    Value merged;
+    merged["foo"]["x"] = "1";
+
+    Value baseline;
+    baseline["foo"] = "leaf";
+
+    const auto diff = merged.diffAgainst(baseline);
+    EXPECT_EQ(diff.get_or("foo.x", wxString { "<missing>" }), "1");
+}

--- a/tests/unit/ValueMergeTests.cpp
+++ b/tests/unit/ValueMergeTests.cpp
@@ -1,0 +1,152 @@
+//
+// FBIde editor for FreeBASIC - https://freebasic.net
+// Copyright (c) 2026 Albert Varaksin
+// Licensed under the MIT License. See LICENSE file for details.
+// https://github.com/albeva/fbide
+//
+#include <gtest/gtest.h>
+#include "config/Value.hpp"
+
+using namespace fbide;
+
+class ValueMergeTests : public testing::Test {};
+
+// ---------------------------------------------------------------------------
+// Empty / no-op cases
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueMergeTests, EmptyOverlayLeavesBaselineUnchanged) {
+    Value baseline;
+    baseline["foo"] = "bundle";
+    baseline["nested"]["x"] = "1";
+
+    const Value overlay;
+    baseline.mergeFrom(overlay);
+
+    EXPECT_EQ(baseline.get_or("foo", wxString { "<sentinel>" }), "bundle");
+    EXPECT_EQ(baseline.get_or("nested.x", wxString { "<sentinel>" }), "1");
+}
+
+// ---------------------------------------------------------------------------
+// Leaf overrides
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueMergeTests, OverlayLeafReplacesBaselineLeaf) {
+    Value baseline;
+    baseline["foo"] = "bundle";
+
+    Value overlay;
+    overlay["foo"] = "user";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("foo", wxString {}), "user");
+}
+
+TEST_F(ValueMergeTests, OverlayLeafAtNewPathIsAdded) {
+    Value baseline;
+    baseline["foo"] = "bundle";
+
+    Value overlay;
+    overlay["bar"] = "added";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("foo", wxString {}), "bundle");
+    EXPECT_EQ(baseline.get_or("bar", wxString { "<sentinel>" }), "added");
+}
+
+TEST_F(ValueMergeTests, BaselineKeyNotInOverlayIsPreserved) {
+    Value baseline;
+    baseline["keep"] = "yes";
+    baseline["replace"] = "old";
+
+    Value overlay;
+    overlay["replace"] = "new";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("keep", wxString {}), "yes");
+    EXPECT_EQ(baseline.get_or("replace", wxString {}), "new");
+}
+
+// ---------------------------------------------------------------------------
+// Empty-string overrides — key-presence wins regardless of value. Aggressive
+// pruning later will only persist keys whose value differs from baseline;
+// here we verify that an explicit empty value in the overlay still wins.
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueMergeTests, EmptyStringOverlayValueStillOverrides) {
+    Value baseline;
+    baseline["foo"] = "bundle";
+
+    Value overlay;
+    overlay["foo"] = "";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("foo", wxString { "<sentinel>" }), "");
+}
+
+// ---------------------------------------------------------------------------
+// Nested groups
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueMergeTests, NestedGroupsMergeRecursively) {
+    Value baseline;
+    baseline["editor"]["tabSize"] = "4";
+    baseline["editor"]["theme"] = "dark";
+    baseline["editor"]["font"] = "Menlo";
+
+    Value overlay;
+    overlay["editor"]["theme"] = "solarized"; // override existing
+    overlay["editor"]["wrap"] = "true";       // add new in same group
+
+    baseline.mergeFrom(overlay);
+
+    EXPECT_EQ(baseline.get_or("editor.tabSize", wxString {}), "4");               // untouched
+    EXPECT_EQ(baseline.get_or("editor.font", wxString {}), "Menlo");              // untouched
+    EXPECT_EQ(baseline.get_or("editor.theme", wxString {}), "solarized");         // overridden
+    EXPECT_EQ(baseline.get_or("editor.wrap", wxString { "<sentinel>" }), "true"); // added
+}
+
+TEST_F(ValueMergeTests, DeeplyNestedGroupsMergeRecursively) {
+    Value baseline;
+    baseline["a"]["b"]["c"] = "1";
+    baseline["a"]["b"]["d"] = "2";
+
+    Value overlay;
+    overlay["a"]["b"]["c"] = "overridden";
+    overlay["a"]["b"]["e"] = "added";
+
+    baseline.mergeFrom(overlay);
+
+    EXPECT_EQ(baseline.get_or("a.b.c", wxString {}), "overridden");
+    EXPECT_EQ(baseline.get_or("a.b.d", wxString {}), "2");
+    EXPECT_EQ(baseline.get_or("a.b.e", wxString { "<sentinel>" }), "added");
+}
+
+// ---------------------------------------------------------------------------
+// Type-mismatch — overlay always wins. INI overlays mirror base structure
+// so these aren't typical, but the rule must be consistent in case a
+// hand-edited overlay drifts.
+// ---------------------------------------------------------------------------
+
+TEST_F(ValueMergeTests, OverlayLeafReplacesBaselineGroup) {
+    Value baseline;
+    baseline["foo"]["x"] = "1";
+    baseline["foo"]["y"] = "2";
+
+    Value overlay;
+    overlay["foo"] = "leaf";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("foo", wxString {}), "leaf");
+}
+
+TEST_F(ValueMergeTests, OverlayGroupReplacesBaselineLeaf) {
+    Value baseline;
+    baseline["foo"] = "leaf";
+
+    Value overlay;
+    overlay["foo"]["x"] = "1";
+
+    baseline.mergeFrom(overlay);
+    EXPECT_EQ(baseline.get_or("foo.x", wxString { "<sentinel>" }), "1");
+}

--- a/tests/unit/ValueMergeTests.cpp
+++ b/tests/unit/ValueMergeTests.cpp
@@ -9,6 +9,9 @@
 
 using namespace fbide;
 
+// gtest fixtures are referenced by TEST_F macro expansion and
+// idiomatically stay at file scope.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 class ValueMergeTests : public testing::Test {};
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces the one-shot READONLY-mirror (`copyMissingResources` on first launch) with per-category `<base>.local.ini` overlays for `config`, `keywords`, `shortcuts`, `layout`. Bundle defaults now flow through to existing users on upgrade; only divergent values persist in the overlay (aggressive prune on save).
- `READONLY` sentinel reduced to a routing flag — overlays land in `<UserDataDir>` when present, alongside the bundle file otherwise. Themes get an analogous two-dir model: bundle + user themes dirs enumerated together, user shadows bundle on basename collision, edits save into the writable side.
- Locale stays bundle-only; `save(Locale)` is refused with an error. `--config=PATH` runs all four mutable categories in `Direct` mode (no overlay) for CI/repro reproducibility; `reloadConfig` cascades the same flip to sub-categories at runtime.

13 commits, +1607 / -169 lines, full plan in `docs/layered-config.md`. Unit suite: 409 → 449 (+40). Pre-release migration of legacy mirrored user-data was deliberately skipped (FBIde has only shipped beta/rc to date).

## Test plan

- [x] `ctest --test-dir build/claude/clang/debug -LE gui` — 449/449 green
- [x] `clang-tidy` over `ConfigManager.{hpp,cpp}` + `ConfigStrategy.{hpp,cpp}` clean
- [x] `cmake --build` produces a fresh `bin/fbide.app` bundle (READONLY sentinel ships from `resources/pristine/`)
- [ ] Manual smoke on the .app bundle: launch, change a Settings value + edit a theme, quit, restart → confirm `<UserDataDir>/<base>.local.ini` contains only the change and `<UserDataDir>/themes/<x>.ini` shadows the bundle theme; then hand-edit a non-overridden key in the bundle config and restart → new bundle default visible