### PR TITLE
0.5.0-rc.3

### DIFF
--- a/src/lib/editor/Editor.cpp
+++ b/src/lib/editor/Editor.cpp
@@ -788,7 +788,7 @@ void Editor::uncommentSelection() {
 void Editor::onUpdateUI(wxStyledTextEvent& event) {
     event.Skip();
 
-    if (m_docType != DocumentType::FreeBASIC || m_editorLocked) {
+    if (m_editorLocked) {
         return;
     }
 
@@ -798,6 +798,10 @@ void Editor::onUpdateUI(wxStyledTextEvent& event) {
     if (not m_callPostUpdate && (selection || content)) {
         m_callPostUpdate = true;
         CallAfter(&Editor::postUpdateUI);
+    }
+
+    if (m_docType != DocumentType::FreeBASIC) {
+        return;
     }
 
     const int curr = GetCurrentPos();


### PR DESCRIPTION
# Changes since 0.5.0-rc.2

- Added change tracking (#1)
- Added a confirm-and-close prompt when Save As targets a file already open in another tab
- Added basic Markdown syntax highlighting for `.md` / `.markdown` files
- Added basic Windows batch syntax highlighting for `.bat` / `.cmd` files
- Added basic shell script syntax highlighting for `.sh` / `.bash` files
- Added basic Makefile syntax highlighting (`Makefile`, `GNUmakefile`, `.mk`, `.make`)
- Added basic JSON syntax highlighting for `.json` / `.json5` files
- Added basic CSS syntax highlighting for `.css` files
- Added a document type indicator to the status bar
- Added option to override document type (right click on type indicator in the status bar)
- Changed fbide now stores config changes in `.local.`, keeping original base files immutable.
- Fixed `#include` opening the same file in multiple tabs on case-insensitive filesystems (#87)
- Fixed issue with folding where the opener was followed by empty lines.