### PR TITLE
0.5.0.rc-4

### DIFF
--- a/.github/actions/setup-wx/action.yml
+++ b/.github/actions/setup-wx/action.yml
@@ -89,9 +89,12 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
+        # libcurl4-openssl-dev provides the libcurl backend wxWebRequest
+        # needs on Linux; without it wx builds with wxUSE_WEBREQUEST=0.
         sudo apt-get install -y --no-install-recommends \
           build-essential ninja-build pkg-config \
-          libgtk-3-dev libglib2.0-dev libsecret-1-dev libnotify-dev
+          libgtk-3-dev libglib2.0-dev libsecret-1-dev libnotify-dev \
+          libcurl4-openssl-dev
 
     - name: Build wxWidgets (Windows)
       if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,12 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
+          # libcurl4-openssl-dev: links the libcurl backend that static wx's
+          # wxWebRequest pulls in (and bundles libcurl into the AppImage).
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config \
             libgtk-3-dev libglib2.0-dev libsecret-1-dev libnotify-dev \
+            libcurl4-openssl-dev \
             imagemagick file fuse libfuse2
 
       - name: Set up wxWidgets (GTK3)

--- a/change-log.md
+++ b/change-log.md
@@ -5,6 +5,7 @@
 - Added compiler auto detection.
 - Added include file resolution to include "-i" from compile command.
 - Added run command to the log.
+- Added version checker, which shows a message box if there is a new version of fbide.
 - Fixed indent issue with indenting when "operator" and "property" are used as expressions (#94).
 - Fixed console min height (#95).
 

--- a/resources/pristine/config_linux.ini
+++ b/resources/pristine/config_linux.ini
@@ -32,17 +32,13 @@ splashScreen=1
 [commands]
 ; ----------------------------------------------------------------------------
 ; Editor view preferences — all booleans are 0/1.
-;   edgeColumn   right-margin column hint (shown when longLine=1).
-;   tabSize      width of one tab in spaces.
-;   encoding     default encoding for new/untitled documents. Stable keys
-;                match TextEncoding::parse — e.g. UTF-8, UTF-8-BOM, UTF-16-LE,
-;                Windows-1252, CP437, System (see src/lib/editor/TextEncoding).
-;   eolMode      default line-ending for new documents: LF, CRLF, or CR.
 ; ----------------------------------------------------------------------------
+viewMinimap=1
+configurationInStatusBar=0
 [editor]
 autoIndent=1
 braceHighlight=1
-changeTracking=0
+changeTracking=1
 displayEOL=0
 edgeColumn=120
 encoding=UTF-8
@@ -69,6 +65,11 @@ path=
 runCommand="<$terminal> \"<$file>\" <$param>"
 compileCommand="\"<$fbc>\" \"<$file>\""
 terminal="x-terminal-emulator -e"
+; ----------------------------------------------------------------------------
+; Enable checking for fbide updates on startup
+; ----------------------------------------------------------------------------
+[update]
+checkOnStartup=1
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/pristine/config_macos.ini
+++ b/resources/pristine/config_macos.ini
@@ -32,17 +32,13 @@ splashScreen=1
 [commands]
 ; ----------------------------------------------------------------------------
 ; Editor view preferences — all booleans are 0/1.
-;   edgeColumn   right-margin column hint (shown when longLine=1).
-;   tabSize      width of one tab in spaces.
-;   encoding     default encoding for new/untitled documents. Stable keys
-;                match TextEncoding::parse — e.g. UTF-8, UTF-8-BOM, UTF-16-LE,
-;                Windows-1252, CP437, System (see src/lib/editor/TextEncoding).
-;   eolMode      default line-ending for new documents: LF, CRLF, or CR.
 ; ----------------------------------------------------------------------------
+viewMinimap=1
+configurationInStatusBar=0
 [editor]
 autoIndent=1
 braceHighlight=1
-changeTracking=0
+changeTracking=1
 displayEOL=0
 edgeColumn=120
 encoding=UTF-8
@@ -66,9 +62,14 @@ whiteSpace=0
 ; ----------------------------------------------------------------------------
 [compiler]
 path=
-runCommand=<$file>
+runCommand="\"<$file>\" <$param>"
 compileCommand="\"<$fbc>\" \"<$file>\""
 terminal=
+; ----------------------------------------------------------------------------
+; Enable checking for fbide updates on startup
+; ----------------------------------------------------------------------------
+[update]
+checkOnStartup=1
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog

--- a/resources/pristine/config_win.ini
+++ b/resources/pristine/config_win.ini
@@ -33,17 +33,13 @@ splashScreen=1
 [commands]
 ; ----------------------------------------------------------------------------
 ; Editor view preferences — all booleans are 0/1.
-;   edgeColumn   right-margin column hint (shown when longLine=1).
-;   tabSize      width of one tab in spaces.
-;   encoding     default encoding for new/untitled documents. Stable keys
-;                match TextEncoding::parse — e.g. UTF-8, UTF-8-BOM, UTF-16-LE,
-;                Windows-1252, CP437, System (see src/lib/editor/TextEncoding).
-;   eolMode      default line-ending for new documents: LF, CRLF, or CR.
 ; ----------------------------------------------------------------------------
+viewMinimap=1
+configurationInStatusBar=0
 [editor]
 autoIndent=1
 braceHighlight=1
-changeTracking=0
+changeTracking=1
 displayEOL=0
 edgeColumn=120
 encoding=UTF-8
@@ -68,8 +64,13 @@ whiteSpace=0
 [compiler]
 path=
 runCommand="\"<$file>\" <$param>"
-compileCommand="\"<$fbc>\" \"<$file>\" -s console"
+compileCommand="\"<$fbc>\" \"<$file>\""
 terminal="cmd /C"
+; ----------------------------------------------------------------------------
+; Enable checking for fbide updates on startup
+; ----------------------------------------------------------------------------
+[update]
+checkOnStartup=1
 ; ----------------------------------------------------------------------------
 ; File dialog wildcard patterns. Each entry holds only the glob(s) for
 ; one filter; multiple globs separate with ";" (e.g. *.bas;*.bi). Dialog


### PR DESCRIPTION
# Changes since 0.5.0-rc.3

- Added multiple compiler configurations.
- Added configuration selector to toolbar or statusbar (configurable).
- Added compiler auto detection.
- Added include file resolution to include "-i" from compile command.
- Added run command to the log.
- Added version checker, which shows a message box if there is a new version of fbide.
- Fixed indent issue with indenting when "operator" and "property" are used as expressions (#94).
- Fixed console min height (#95).