### PR TITLE
0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,18 @@ jobs:
           mac_x86='{"arch":"x86_64","runner":"macos-latest"}'
           # win-targets mirrors macos/linux-targets: a JSON list of
           # {arch, runner} objects fed into build-and-test's matrix.include.
-          # x64/x86 build on the x64 windows-latest image; arm64 builds
-          # natively on the windows-11-arm hosted runner (so ctest runs the
-          # arm64 binaries directly, no cross-compile/emulation).
-          win_x64='{"arch":"x64","runner":"windows-latest"}'
-          win_x86='{"arch":"x86","runner":"windows-latest"}'
+          # x64/x86 are PINNED to windows-2022, NOT windows-latest: GitHub
+          # migrated windows-latest to Windows Server 2025 + Visual Studio
+          # 2026 (VS 18.x) over 8-15 Jun 2026, and VS 2026's toolset drops
+          # Windows 7 targeting. We ship a Win7 SP1 floor, so we stay on the
+          # last VS 2022 image. windows-2022 is GitHub's documented "needs
+          # VS 2022" fallback — do not bump back to windows-latest unless the
+          # Win7 floor is also dropped. arm64 builds natively on the
+          # windows-11-arm hosted runner (no Win7 ARM64 exists, so the VS
+          # version there is irrelevant; ctest runs the arm64 binaries
+          # directly, no cross-compile/emulation).
+          win_x64='{"arch":"x64","runner":"windows-2022"}'
+          win_x86='{"arch":"x86","runner":"windows-2022"}'
           win_arm='{"arch":"arm64","runner":"windows-11-arm"}'
           # linux-targets mirrors macos-targets: a JSON list of {arch, runner}
           # objects fed into build-linux-appimage's matrix.include. Each arch


### PR DESCRIPTION
### Changes since 0.5.0-rc.6

- Added a Windows installer with bundled FreeBASIC (x86).
- Added an arm64 Windows build and an arm64 Linux AppImage.
- Added file associations (.bas, .bi, .fbs).
- Statistically linked the CRT into the Windows builds so they run without the VC++ redistributable.
- Added auto-reload of externally modified files.
- Added auto-refresh, context menus and a folder focus mode to the sidebar File Browser.
- Changed sessions to stay active and auto-save on close or quit, restoring file-browser state.
- Added a `fbide format <file>` command-line subcommand.
- Added a new app icon, splash and distinct file icons for .bas, .bi and .fbs files.
- Redesigned the About dialogue.
- Fixed an operator before a `&h`/`&o`/`&b` number swallowing its prefix and mis-highlighting the number (#111).
- Fixed source commands (Compile/Run/Format) staying disabled when FBIDE is launched by opening a file (#122).
- Fixed Compile & Run / Quick Run on a configuration that builds no executable, now showing a clear alert (#116).
- Fixed `_` in a `##_##` preprocessor token-paste being mis-lexed as a line continuation (#115).
- Added opening common extensionless files (Makefile, README, LICENSE, …) from the file browser (#114).
- Changed the Open dialogue to default to the FBIde filter (`*.bas`, `*.bi`, `*.fbs`); removed "Load Session".
- Added native file/folder icons to the macOS file browser.
- Fixed Comment/Uncomment changing the text selection (#113).
- Fixed a keyword after `.`/`->` followed by a non-identifier losing its highlighting (#112).
- Added an editor notification bar when a file fails to save.
- Added highlighting of every occurrence of the identifier under the caret.
- Added highlighting of matching scope keywords under the caret (For/Next, Sub/End Sub, If/Else/End If, …).
- Added code completion as you type, including symbols from `#include`d files (Ctrl+Space).
- Added Go to Definition / Go to Declaration, jumping across `#include`d files.
- Added imported (`#include`d) symbols to the symbol browser, nested under each include.
- Added preprocessor-aware intellisense — `#if` branches resolved against compiler defines; inactive code dimmed.
- Fixed right-clicking a document tab closing it instead of showing the context menu on Linux.