### PR TITLE
0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,13 +305,13 @@ jobs:
       - name: Build
         run: cmake --build build/ci
 
-      # GUI tests carry the `gui` label and are Windows-targeted, so x64/x86
-      # run the full suite. The windows-11-arm hosted runner has no
-      # interactive desktop session to drive them, so skip the label there —
-      # same treatment the Linux/macOS jobs give their GUI suites.
-      - name: Test
+      # GUI tests carry the `gui` label (see tests/CMakeLists.txt). The hosted
+      # runners have no interactive desktop session to instantiate wx GUI
+      # controls, so skip the whole `gui` suite on every arch — same treatment
+      # the Linux/macOS jobs give their GUI suites.
+      - name: Test (non-GUI)
         working-directory: build/ci
-        run: ctest --output-on-failure ${{ matrix.arch == 'arm64' && '-LE gui' || '' }}
+        run: ctest --output-on-failure -LE gui
 
       # ---------- Release artefact (push to main, all archs) ----------
       # Each matrix instance produces its own zip; the release job


### PR DESCRIPTION
- Updated wxWudgets to 3.3.3 (#130)
- Added fbide now remembers formatting options (#132).
- Added a "Reformat" that formats the whole document, or just the selected lines (#132).
- Added a "Save Session As…" command to save the active session to a new file (#129).
- Added FreeBASIC syntax highlighting for `.inc` include files (#128).
- Fixed the formatter inserting stray spaces in `#n` file numbers, `=>`, and unary `*`/`@` before a parenthesis (#128).
- Fixed a crash when pasting or dragging text over the last line of a FreeBASIC file (#131, #128).
- Fixed `!"…"` / `$"…"` string-literal prefixes being split from their string (#128).
- Fixed the Windows build being DPI-unaware, causing a blurry UI on high-DPI displays (#128).
- Fixed FBIde sometimes closing or freezing after the first launch on Windows (#127).